### PR TITLE
Params from env

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,7 @@ test:
         -e TEST_MSSQL_PORT="${TEST_MSSQL_PORT}" \
         -e TEST_MSSQL_DBNAME="${TEST_MSSQL_DBNAME}" \
         -e TEST_MSSQL_PASSWORD="${TEST_MSSQL_PASSWORD}" \
-        "$CI_REGISTRY_IMAGE:test-runner" pytest --cov=etlhelper -vs test/
+        "$CI_REGISTRY_IMAGE:test-runner" pytest -rsx --cov=etlhelper -vs test/
 
 package:
   tags:

--- a/README.md
+++ b/README.md
@@ -109,8 +109,11 @@ from etlhelper import DbParams
 
 ORACLEDB = DbParams(host="localhost", port=1521,
                     database="mydata",
-                    username="oracle_user")
+                    user="oracle_user")
 ```
+
+DbParams objects can also be created from environment variables using the
+`from_environment()` function.
 
 #### Get rows
 

--- a/bin/run_tests_for_developer.sh
+++ b/bin/run_tests_for_developer.sh
@@ -19,7 +19,7 @@ docker run \
   --net=host \
   --name=etlhelper-test-runner \
   etlhelper-test-runner \
-  pytest -vs --cov=etlhelper --cov-report html --cov-report term test/
+  pytest -vs -rsx --cov=etlhelper --cov-report html --cov-report term test/
 
 # Copy coverage files out of container to local if tests passed
 if [ $? -eq 0 ]; then

--- a/etlhelper/db_helpers/mssql.py
+++ b/etlhelper/db_helpers/mssql.py
@@ -15,7 +15,7 @@ class SqlServerDbHelper(DbHelper):
             self.sql_exceptions = (pyodbc.DatabaseError)
             self._connect_func = pyodbc.connect
             self.connect_exceptions = (pyodbc.DatabaseError, pyodbc.InterfaceError)
-            self.required_params = {'host', 'port', 'dbname', 'username', 'odbc_driver'}
+            self.required_params = {'host', 'port', 'dbname', 'user', 'odbc_driver'}
         except ImportError:
             print("The pyodc Python package could not be found.\n"
                   "Run: python -m pip install pyodbc")
@@ -30,7 +30,7 @@ class SqlServerDbHelper(DbHelper):
         # Prepare connection string
         password = self.get_password(password_variable)
         return (f'DRIVER={db_params.odbc_driver};SERVER=tcp:{db_params.host};PORT={db_params.port};'
-                f'DATABASE={db_params.dbname};UID={db_params.username};PWD={password}')
+                f'DATABASE={db_params.dbname};UID={db_params.user};PWD={password}')
 
     def get_sqlalchemy_connection_string(self, db_params, password_variable):
         """
@@ -38,6 +38,6 @@ class SqlServerDbHelper(DbHelper):
         """
         password = self.get_password(password_variable)
         driver = db_params.odbc_driver.replace(" ", "+")
-        return (f'mssql+pyodbc://{db_params.username}:{password}@'
+        return (f'mssql+pyodbc://{db_params.user}:{password}@'
                 f'{db_params.host}:{db_params.port}/{db_params.dbname}?'
                 f'driver={driver}')

--- a/etlhelper/db_helpers/oracle.py
+++ b/etlhelper/db_helpers/oracle.py
@@ -15,7 +15,7 @@ class OracleDbHelper(DbHelper):
             self.sql_exceptions = (cx_Oracle.DatabaseError)
             self._connect_func = cx_Oracle.connect
             self.connect_exceptions = (cx_Oracle.DatabaseError)
-            self.required_params = {'host', 'port', 'dbname', 'username'}
+            self.required_params = {'host', 'port', 'dbname', 'user'}
         except ImportError:
             print("The cxOracle drivers were not found. See setup guide for more information.")
 
@@ -28,7 +28,7 @@ class OracleDbHelper(DbHelper):
         """
         # Prepare connection string
         password = self.get_password(password_variable)
-        return (f'{db_params.username}/{password}@'
+        return (f'{db_params.user}/{password}@'
                 f'{db_params.host}:{db_params.port}/{db_params.dbname}')
 
     def get_sqlalchemy_connection_string(self, db_params, password_variable):
@@ -37,5 +37,5 @@ class OracleDbHelper(DbHelper):
         """
         password = self.get_password(password_variable)
 
-        return (f'oracle://{db_params.username}:{password}@'
+        return (f'oracle://{db_params.user}:{password}@'
                 f'{db_params.host}:{db_params.port}/{db_params.dbname}')

--- a/etlhelper/db_helpers/postgres.py
+++ b/etlhelper/db_helpers/postgres.py
@@ -15,7 +15,7 @@ class PostgresDbHelper(DbHelper):
             self.sql_exceptions = (psycopg2.ProgrammingError)
             self._connect_func = psycopg2.connect
             self.connect_exceptions = (psycopg2.OperationalError)
-            self.required_params = {'host', 'port', 'dbname', 'username'}
+            self.required_params = {'host', 'port', 'dbname', 'user'}
         except ImportError:
             print("The PostgreSQL python libraries could not be found.\n"
                   "Run: python -m pip install psycopg2-binary")
@@ -31,14 +31,14 @@ class PostgresDbHelper(DbHelper):
         password = self.get_password(password_variable)
         return (f'host={db_params.host} port={db_params.port} '
                 f'dbname={db_params.dbname} '
-                f'user={db_params.username} password={password}')
+                f'user={db_params.user} password={password}')
 
     def get_sqlalchemy_connection_string(self, db_params, password_variable):
         """
         Returns connection string for sql alchemy
         """
         password = self.get_password(password_variable)
-        return (f'postgresql://{db_params.username}:{password}@'
+        return (f'postgresql://{db_params.user}:{password}@'
                 f'{db_params.host}:{db_params.port}/{db_params.dbname}')
 
     @staticmethod

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,7 +18,7 @@ PGTESTDB = DbParams(
     host='localhost',
     port=5432,
     dbname='etlhelper',
-    username='etlhelper_user')
+    user='etlhelper_user')
 
 
 @pytest.fixture('module')

--- a/test/integration/db/test_oracle.py
+++ b/test/integration/db/test_oracle.py
@@ -10,16 +10,12 @@ import cx_Oracle
 import pytest
 
 from etlhelper import connect, get_rows, copy_rows, DbParams
-from etlhelper.exceptions import ETLHelperError, ETLHelperConnectionError
+from etlhelper.exceptions import ETLHelperConnectionError
 from test.conftest import db_is_unreachable
 
 # Skip these tests if database is unreachable
-try:
-    ORADB = DbParams.from_environment(prefix='TEST_ORACLE_')
-    if db_is_unreachable(ORADB.host, ORADB.port):
-        raise ETLHelperConnectionError()
-except (ETLHelperError, TypeError):
-    # TypeError thrown if host not set, others subclass ETLHelperError
+ORADB = DbParams.from_environment(prefix='TEST_ORACLE_')
+if db_is_unreachable(ORADB.host, ORADB.port):
     pytest.skip('Oracle test database is unreachable', allow_module_level=True)
 
 

--- a/test/unit/test_db_helpers.py
+++ b/test/unit/test_db_helpers.py
@@ -15,7 +15,7 @@ from etlhelper.db_helpers import (OracleDbHelper, SqlServerDbHelper, PostgresDbH
 @pytest.fixture()
 def params():
     return DbParams(dbtype='ORACLE', odbc_driver='test driver', host='testhost',
-                    port=1521, dbname='testdb', username='testuser')
+                    port=1521, dbname='testdb', user='testuser')
 
 
 def test_oracle_sql_exceptions():
@@ -34,7 +34,7 @@ def test_oracle_connect(monkeypatch):
     # TODO: Fix DbParams class to take driver as init input.
     db_params = DbParams(dbtype='ORACLE',
                          host='server', port='1521', dbname='testdb',
-                         username='testuser')
+                         user='testuser')
     monkeypatch.setenv('DB_PASSWORD', 'mypassword')
     expected_conn_str = 'testuser/mypassword@server:1521/testdb'
 
@@ -52,7 +52,7 @@ def test_oracle_connect(monkeypatch):
 def test_sqlserver_connect(monkeypatch):
     db_params = DbParams(dbtype='MSSQL',
                          host='server', port='1521', dbname='testdb',
-                         username='testuser', odbc_driver='test driver')
+                         user='testuser', odbc_driver='test driver')
     monkeypatch.setenv('DB_PASSWORD', 'mypassword')
     expected_conn_str = ('DRIVER=test driver;SERVER=tcp:server;PORT=1521;'
                          'DATABASE=testdb;UID=testuser;PWD=mypassword')
@@ -71,7 +71,7 @@ def test_sqlserver_connect(monkeypatch):
 def test_postgres_connect(monkeypatch):
     db_params = DbParams(dbtype='PG',
                          host='server', port='1521', dbname='testdb',
-                         username='testuser', odbc_driver='test driver')
+                         user='testuser', odbc_driver='test driver')
     monkeypatch.setenv('DB_PASSWORD', 'mypassword')
     expected_conn_str = 'host=server port=1521 dbname=testdb user=testuser password=mypassword'
     mock_connect = Mock()
@@ -89,7 +89,7 @@ def test_postgres_connect(monkeypatch):
 def test_oracle_sqlalchemy_conn_string(monkeypatch):
     db_params = DbParams(dbtype='ORACLE',
                          host='server', port='1521', dbname='testdb',
-                         username='testuser')
+                         user='testuser')
     monkeypatch.setenv('DB_PASSWORD', 'mypassword')
     helper = OracleDbHelper()
     conn_str = helper.get_sqlalchemy_connection_string(db_params, 'DB_PASSWORD')
@@ -101,7 +101,7 @@ def test_oracle_sqlalchemy_conn_string(monkeypatch):
 def test_sqlserver_sqlalchemy_connect(monkeypatch):
     db_params = DbParams(dbtype='MSSQL',
                          host='server', port='1521', dbname='testdb',
-                         username='testuser', odbc_driver='test driver')
+                         user='testuser', odbc_driver='test driver')
     monkeypatch.setenv('DB_PASSWORD', 'mypassword')
     helper = SqlServerDbHelper()
     conn_str = helper.get_sqlalchemy_connection_string(db_params, 'DB_PASSWORD')
@@ -113,7 +113,7 @@ def test_sqlserver_sqlalchemy_connect(monkeypatch):
 def test_postgres_sqlalchemy_connect(monkeypatch):
     db_params = DbParams(dbtype='PG',
                          host='server', port='1521', dbname='testdb',
-                         username='testuser')
+                         user='testuser')
     monkeypatch.setenv('DB_PASSWORD', 'mypassword')
     helper = PostgresDbHelper()
     conn_str = helper.get_sqlalchemy_connection_string(db_params, 'DB_PASSWORD')

--- a/test/unit/test_db_params.py
+++ b/test/unit/test_db_params.py
@@ -19,10 +19,11 @@ def test_db_params_repr():
         host='localhost',
         port=5432,
         dbname='etlhelper',
-        username='etlhelper_user')
+        user='etlhelper_user')
     result = str(test_params)
     expected = ("DbParams(host='localhost', "
-                "port='5432', dbname='etlhelper', username='etlhelper_user', dbtype='PG')")
+                "port='5432', dbname='etlhelper', "
+                "user='etlhelper_user', dbtype='PG')")
     assert result == expected
 
 
@@ -31,18 +32,31 @@ def test_db_params_from_environment(monkeypatch):
     Test capturing db params from environment settings.
     """
     # Arrange
-    monkeypatch.setenv('TEST_DBTYPE', 'ORACLE')
-    monkeypatch.setenv('TEST_HOST', 'test.host')
-    monkeypatch.setenv('TEST_PORT', '1234')
-    monkeypatch.setenv('TEST_DBNAME', 'testdb')
-    monkeypatch.setenv('TEST_USER', 'testuser')
+    monkeypatch.setenv('TEST_DB_PARAMS_ENV_DBTYPE', 'ORACLE')
+    monkeypatch.setenv('TEST_DB_PARAMS_ENV_HOST', 'test.host')
+    monkeypatch.setenv('TEST_DB_PARAMS_ENV_PORT', '1234')
+    monkeypatch.setenv('TEST_DB_PARAMS_ENV_DBNAME', 'testdb')
+    monkeypatch.setenv('TEST_DB_PARAMS_ENV_USER', 'testuser')
 
     # Act
-    db_params = DbParams.from_environment(prefix='TEST_')
+    db_params = DbParams.from_environment(prefix='TEST_DB_PARAMS_ENV_')
 
     # Assert
     db_params.dbtype = 'ORACLE'
     db_params.host = 'test.host'
     db_params.port = '1234'
     db_params.dbname = 'testdb'
-    db_params.username = 'testuser'
+    db_params.user = 'testuser'
+
+
+def test_db_params_from_environment_not_set(monkeypatch):
+    """
+    Test missing db params from environment settings.
+    """
+    # Arrange
+    monkeypatch.delenv('TEST_DBTYPE', raising=False)
+
+    # Act
+    with pytest.raises(ETLHelperDbParamsError,
+                       match=r".*environment variable is not set.*"):
+        DbParams.from_environment(prefix='TEST_')


### PR DESCRIPTION
These commits allow `DbParams.from_environment()` to take advantage of the new, flexible way to specify required parameters.

## To test
+ [x] manually define a database connection from environment variables to confirm that it works
+ [x] confirm all tests work locally, using environment variables from CI environment