### PR TITLE
Add SQLite helper

### DIFF
--- a/bin/run_tests_for_developer.sh
+++ b/bin/run_tests_for_developer.sh
@@ -1,7 +1,14 @@
 #! /bin/sh
+echo "Building container"
 docker build \
   --build-arg INSTANT_CLIENT_ZIP=${INSTANT_CLIENT_ZIP} \
   -t etlhelper-test-runner . || exit 1
+
+echo "Flake8 checks"
+docker run \
+  etlhelper-test-runner flake8 etlhelper test || exit 1
+
+echo "Unit and integration tests"
 docker run \
   -e TEST_PG_PASSWORD="${TEST_PG_PASSWORD}" \
   -e TEST_ORACLE_DBTYPE="${TEST_ORACLE_DBTYPE}" \

--- a/etlhelper/connect.py
+++ b/etlhelper/connect.py
@@ -4,7 +4,7 @@ Connect to database
 from etlhelper.db_helper_factory import DB_HELPER_FACTORY
 
 
-def connect(db_params, password_variable, **kwargs):
+def connect(db_params, password_variable=None, **kwargs):
     """
     Return database connection.
 

--- a/etlhelper/db_helper_factory.py
+++ b/etlhelper/db_helper_factory.py
@@ -6,6 +6,7 @@ Factory pattern that generates DbHelpers foreach DB type
 from etlhelper.db_helpers.oracle import OracleDbHelper
 from etlhelper.db_helpers.postgres import PostgresDbHelper
 from etlhelper.db_helpers.mssql import SqlServerDbHelper
+from etlhelper.db_helpers.sqlite import SQLiteDbHelper
 from etlhelper.exceptions import ETLHelperHelperError
 
 
@@ -69,3 +70,5 @@ DB_HELPER_FACTORY.register_helper('PG', "<class 'psycopg2.extensions.connection'
                                   PostgresDbHelper)
 DB_HELPER_FACTORY.register_helper('MSSQL', "<class 'pyodbc.Connection'>",
                                   SqlServerDbHelper)
+DB_HELPER_FACTORY.register_helper('SQLITE', "<class 'sqlite3.Connection'>",
+                                  SQLiteDbHelper)

--- a/etlhelper/db_helpers/__init__.py
+++ b/etlhelper/db_helpers/__init__.py
@@ -5,3 +5,4 @@ init db_helpers
 from etlhelper.db_helpers.oracle import OracleDbHelper
 from etlhelper.db_helpers.postgres import PostgresDbHelper
 from etlhelper.db_helpers.mssql import SqlServerDbHelper
+from etlhelper.db_helpers.sqlite import SQLiteDbHelper

--- a/etlhelper/db_helpers/db_helper.py
+++ b/etlhelper/db_helpers/db_helper.py
@@ -25,7 +25,7 @@ class DbHelper(metaclass=ABCMeta):
         # Throws exception if not overidden
         self._connect_func = lambda conn_str: 1/0
 
-    def connect(self, db_params, password_variable, **kwargs):
+    def connect(self, db_params, password_variable=None, **kwargs):
         """
         Return a connection (as appropriate), configured for
         the database with the password obtained from environment variable.  These
@@ -80,10 +80,19 @@ class DbHelper(metaclass=ABCMeta):
     @staticmethod
     def executemany(cursor, query, chunk):
         """
-        Call executemany method appropriate to database.
+        Call executemany method appropriate to database.  Overridden for PostgreSQL.
 
         :param cursor: Open database cursor.
         :param query: str, SQL query
         :param chunk: list, Rows of parameters.
         """
         cursor.executemany(query, chunk)
+
+    @staticmethod
+    def cursor(conn):
+        """
+        Return a cursor on the connection.  Overridded for SQLite.
+
+        :param conn: Open database connection.
+        """
+        return conn.cursor()

--- a/etlhelper/db_helpers/sqlite.py
+++ b/etlhelper/db_helpers/sqlite.py
@@ -1,0 +1,55 @@
+"""
+Database helper for SQLite
+"""
+from contextlib import contextmanager
+from etlhelper.db_helpers.db_helper import DbHelper
+
+
+class SQLiteDbHelper(DbHelper):
+    """
+    SQLite DB helper class
+    """
+    def __init__(self):
+        super().__init__()
+        try:
+            import sqlite3
+            self.sql_exceptions = (sqlite3.OperationalError,
+                                   sqlite3.IntegrityError)
+            self._connect_func = sqlite3.connect
+            self.connect_exceptions = (sqlite3.OperationalError)
+            self.required_params = {'filename'}
+        except ImportError:
+            print("The sqlite3 module was not found. Check configuration as "
+                  "it should be in Python's standard library.")
+
+    def get_connection_string(self, db_params, password_variable=None):
+        """
+        Return a connection string
+        :param db_params: DbParams
+        :return: str
+        """
+        # Prepare connection string
+        # Accept unused password_variable for consistency with other databases
+        return (f'{db_params.filename}')
+
+    def get_sqlalchemy_connection_string(self, db_params,
+                                         password_variable=None):
+        """
+        Returns connection string for SQLAlchemy type connections
+        :param db_params: DbParams
+        :return: str
+        """
+        return (f'sqlite:///{db_params.filename}')
+
+    @staticmethod
+    @contextmanager
+    def cursor(conn):
+        """
+        Return a cursor on current connection.  This implementation allows
+        SQLite cursor to be used as context manager as with other db types.
+        """
+        try:
+            cursor = conn.cursor()
+            yield cursor
+        finally:
+            cursor.close()

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -45,7 +45,7 @@ def iter_chunks(select_query, conn, parameters=(),
     :param read_lob: bool, convert Oracle LOB objects to strings
     """
     helper = DB_HELPER_FACTORY.from_conn(conn)
-    with conn.cursor() as cursor:
+    with helper.cursor(conn) as cursor:
         # Run query
         try:
             cursor.execute(select_query, parameters)
@@ -170,7 +170,7 @@ def executemany(query, rows, conn, commit_chunks=True):
     helper = DB_HELPER_FACTORY.from_conn(conn)
     processed = 0
 
-    with conn.cursor() as cursor:
+    with helper.cursor(conn) as cursor:
         for chunk in _chunker(rows, CHUNKSIZE):
             # Run query
             try:
@@ -239,7 +239,7 @@ def execute(query, conn, parameters=()):
     :param parameters: sequence or dict of bind variables to insert in the query
     """
     helper = DB_HELPER_FACTORY.from_conn(conn)
-    with conn.cursor() as cursor:
+    with helper.cursor(conn) as cursor:
         # Run query
         try:
             cursor.execute(query, parameters)

--- a/test/integration/db/test_sqlite.py
+++ b/test/integration/db/test_sqlite.py
@@ -23,13 +23,15 @@ def test_connect(sqlitedb):
 
 
 @pytest.mark.skipif(sys.platform != 'linux', reason='Requires Linux OS')
-def test_bad_connect():
-    if os.getenv('USER') == 'root':
-        # Don't run for root user, but don't mark as skipped either
-        return
-    db_params = DbParams(dbtype='SQLITE', filename='/cannot_write_to_root')
-    with pytest.raises(ETLHelperConnectionError):
-        connect(db_params)
+def test_bad_connect(tmpdir):
+    # Attemping to create file in non-existent directory should fail
+    try:
+        db_params = DbParams(dbtype='SQLITE', filename='/does/not/exist')
+        with pytest.raises(ETLHelperConnectionError):
+            connect(db_params)
+    finally:
+        # Restore permissions prior to cleanup
+        os.chmod(tmpdir, 0o666)
 
 
 def test_bad_select(testdb_conn):

--- a/test/integration/db/test_sqlite.py
+++ b/test/integration/db/test_sqlite.py
@@ -1,0 +1,158 @@
+"""Integration tests for SQLite database.
+These currently run against internal BGS instance.
+"""
+# pylint: disable=unused-argument, missing-docstring
+import datetime as dt
+import os
+import sqlite3
+import sys
+from textwrap import dedent
+
+import pytest
+
+from etlhelper import connect, get_rows, copy_rows, execute, DbParams
+from etlhelper.exceptions import ETLHelperConnectionError, ETLHelperQueryError
+
+
+# -- Tests here --
+
+def test_connect(sqlitedb):
+    conn = connect(sqlitedb)
+    assert isinstance(conn, sqlite3.Connection)
+    assert os.path.isfile(sqlitedb.filename)
+
+
+@pytest.mark.skipif(sys.platform != 'linux', reason='Requires Linux OS')
+def test_bad_connect():
+    if os.getenv('USER') == 'root':
+        # Don't run for root user, but don't mark as skipped either
+        return
+    db_params = DbParams(dbtype='SQLITE', filename='/cannot_write_to_root')
+    with pytest.raises(ETLHelperConnectionError):
+        connect(db_params)
+
+
+def test_bad_select(testdb_conn):
+    select_sql = "SELECT * FROM bad_table"
+    with pytest.raises(ETLHelperQueryError):
+        execute(select_sql, testdb_conn)
+
+
+def test_bad_insert(testdb_conn):
+    insert_sql = "INSERT INTO bad_table (id) VALUES (1)"
+    with pytest.raises(ETLHelperQueryError):
+        execute(insert_sql, testdb_conn)
+
+
+def test_bad_constraint(test_tables, testdb_conn):
+    # src already has a row with id=1
+    insert_sql = "INSERT INTO src (id) VALUES (1)"
+    with pytest.raises(ETLHelperQueryError):
+        execute(insert_sql, testdb_conn)
+
+
+def test_copy_rows_happy_path(test_tables, testdb_conn, test_table_data):
+    # Arrange and act
+    select_sql = "SELECT * FROM src"
+    insert_sql = INSERT_SQL.format(tablename='dest')
+    copy_rows(select_sql, testdb_conn, insert_sql, testdb_conn)
+
+    # Assert
+    sql = "SELECT * FROM dest"
+    result = get_rows(sql, testdb_conn)
+
+    # Fix result date and datetime strings to native classes
+    fixed = []
+    for row in result:
+        fixed.append((
+            *row[:4],
+            dt.datetime.strptime(row.day, '%Y-%m-%d').date(),
+            dt.datetime.strptime(row.date_time, '%Y-%m-%d %H:%M:%S')
+        ))
+
+    assert fixed == test_table_data
+
+
+def test_get_rows_with_parameters(pgtestdb_test_tables, pgtestdb_conn,
+                                  test_table_data):
+    # parameters=None is tested by default in other tests
+
+    # Bind by index
+    sql = "SELECT * FROM src where ID = %s"
+    result = get_rows(sql, pgtestdb_conn, parameters=(1,))
+    assert result == [test_table_data[0]]
+
+
+# -- Fixtures here --
+
+INSERT_SQL = dedent("""
+    INSERT INTO {tablename} (id, value, simple_text, utf8_text,
+      day, date_time)
+    VALUES
+      (?, ?, ?, ?, ?, ?)
+      """).strip()
+
+
+@pytest.fixture(scope='function')
+def sqlitedb(tmp_path):
+    """Get DbParams for temporary SQLite database."""
+    filename = f'{tmp_path.absolute()}.db'
+    yield DbParams(dbtype='SQLITE', filename=filename)
+
+
+@pytest.fixture(scope='function')
+def testdb_conn(sqlitedb):
+    """Get connection to test SQLite database."""
+    with connect(sqlitedb) as conn:
+        yield conn
+
+
+@pytest.fixture(scope='function')
+def test_tables(test_table_data, testdb_conn):
+    """
+    Create a table and fill with test data.  Teardown after the yield drops it
+    again.
+    """
+    # Define SQL queries
+    drop_src_sql = "DROP TABLE src"
+    create_src_sql = dedent("""
+        CREATE TABLE src
+          (
+            id INTEGER PRIMARY KEY,
+            value float,
+            simple_text text,
+            utf8_text text,
+            day date,
+            date_time datetime
+          )
+          """).strip()
+    drop_dest_sql = drop_src_sql.replace('src', 'dest')
+    create_dest_sql = create_src_sql.replace('src', 'dest')
+
+    # Create table and populate with test data
+    cursor = testdb_conn.cursor()
+    # src table
+    try:
+        cursor.execute(drop_src_sql)
+    except sqlite3.OperationalError:
+        pass
+    cursor.execute(create_src_sql)
+    cursor.executemany(INSERT_SQL.format(tablename='src'),
+                       test_table_data)
+    # dest table
+    try:
+        cursor.execute(drop_dest_sql)
+    except sqlite3.OperationalError:
+        # Error if table doesn't exist
+        pass
+    cursor.execute(create_dest_sql)
+
+    testdb_conn.commit()
+
+    # Return control to calling function until end of test
+    yield
+
+    # Tear down the table after test completes
+    cursor.execute(drop_src_sql)
+    cursor.execute(drop_dest_sql)
+    testdb_conn.commit()

--- a/test/unit/test_db_helpers.py
+++ b/test/unit/test_db_helpers.py
@@ -1,21 +1,33 @@
 """Unit tests for db_helpers module."""
 from unittest.mock import Mock
 import pytest
+import sqlite3
 
 import cx_Oracle
 import pyodbc
 import psycopg2
 
 from etlhelper import DbParams
-from etlhelper.db_helpers import (OracleDbHelper, SqlServerDbHelper, PostgresDbHelper)
+from etlhelper.db_helper_factory import DB_HELPER_FACTORY
+from etlhelper.db_helpers import (
+    OracleDbHelper,
+    SqlServerDbHelper,
+    PostgresDbHelper,
+    SQLiteDbHelper
+)
 
 # pylint: disable=missing-docstring
 
+ORACLEDB = DbParams(dbtype='ORACLE', host='server', port='1521',
+                    dbname='testdb', username='testuser')
 
-@pytest.fixture()
-def params():
-    return DbParams(dbtype='ORACLE', odbc_driver='test driver', host='testhost',
-                    port=1521, dbname='testdb', username='testuser')
+MSSQLDB = DbParams(dbtype='MSSQL', host='server', port='1521', dbname='testdb',
+                   username='testuser', odbc_driver='test driver')
+
+POSTGRESDB = DbParams(dbtype='PG', host='server', port='1521', dbname='testdb',
+                      username='testuser', odbc_driver='test driver')
+
+SQLITEDB = DbParams(dbtype='SQLITE', filename='/myfile.db')
 
 
 def test_oracle_sql_exceptions():
@@ -28,95 +40,39 @@ def test_oracle_connect_exceptions():
     assert helper.connect_exceptions == (cx_Oracle.DatabaseError)
 
 
-# dbapi test connections
-def test_oracle_connect(monkeypatch):
+@pytest.mark.parametrize('db_params, driver, expected', [
+    (ORACLEDB, cx_Oracle, 'testuser/mypassword@server:1521/testdb'),
+    (MSSQLDB, pyodbc,
+     'DRIVER=test driver;SERVER=tcp:server;PORT=1521;DATABASE=testdb;UID=testuser;PWD=mypassword'), # NOQA
+    (POSTGRESDB, psycopg2,
+     'host=server port=1521 dbname=testdb user=testuser password=mypassword'),
+    (SQLITEDB, sqlite3, '/myfile.db')
+])
+def test_connect(monkeypatch, db_params, driver, expected):
     # Arrange
-    # TODO: Fix DbParams class to take driver as init input.
-    db_params = DbParams(dbtype='ORACLE',
-                         host='server', port='1521', dbname='testdb',
-                         username='testuser')
     monkeypatch.setenv('DB_PASSWORD', 'mypassword')
-    expected_conn_str = 'testuser/mypassword@server:1521/testdb'
-
     mock_connect = Mock()
-    monkeypatch.setattr(cx_Oracle, 'connect', mock_connect)
+    monkeypatch.setattr(driver, 'connect', mock_connect)
+    helper = DB_HELPER_FACTORY.from_db_params(db_params)
 
     # Act
-    helper = OracleDbHelper()
     helper.connect(db_params, 'DB_PASSWORD')
 
     # Assert
-    mock_connect.assert_called_with(expected_conn_str)
+    mock_connect.assert_called_with(expected)
 
 
-def test_sqlserver_connect(monkeypatch):
-    db_params = DbParams(dbtype='MSSQL',
-                         host='server', port='1521', dbname='testdb',
-                         username='testuser', odbc_driver='test driver')
+@pytest.mark.parametrize('db_params, expected', [
+    (ORACLEDB, 'oracle://testuser:mypassword@server:1521/testdb'),
+    (MSSQLDB,
+     'mssql+pyodbc://testuser:mypassword@server:1521/testdb?driver=test+driver'),
+    # NOQA
+    (POSTGRESDB, 'postgresql://testuser:mypassword@server:1521/testdb'),
+    (SQLITEDB, 'sqlite:////myfile.db')
+])
+def test_sqlalchemy_conn_string(monkeypatch, db_params, expected):
     monkeypatch.setenv('DB_PASSWORD', 'mypassword')
-    expected_conn_str = ('DRIVER=test driver;SERVER=tcp:server;PORT=1521;'
-                         'DATABASE=testdb;UID=testuser;PWD=mypassword')
-
-    mock_connect = Mock()
-    monkeypatch.setattr(pyodbc, 'connect', mock_connect)
-
-    # Act
-    helper = SqlServerDbHelper()
-    helper.connect(db_params, 'DB_PASSWORD')
-
-    # Assert
-    mock_connect.assert_called_with(expected_conn_str)
-
-
-def test_postgres_connect(monkeypatch):
-    db_params = DbParams(dbtype='PG',
-                         host='server', port='1521', dbname='testdb',
-                         username='testuser', odbc_driver='test driver')
-    monkeypatch.setenv('DB_PASSWORD', 'mypassword')
-    expected_conn_str = 'host=server port=1521 dbname=testdb user=testuser password=mypassword'
-    mock_connect = Mock()
-    monkeypatch.setattr(psycopg2, 'connect', mock_connect)
-
-    # Act
-    helper = PostgresDbHelper()
-    helper.connect(db_params, 'DB_PASSWORD')
-
-    # Assert
-    mock_connect.assert_called_with(expected_conn_str)
-
-
-# sqlalchemy test connections
-def test_oracle_sqlalchemy_conn_string(monkeypatch):
-    db_params = DbParams(dbtype='ORACLE',
-                         host='server', port='1521', dbname='testdb',
-                         username='testuser')
-    monkeypatch.setenv('DB_PASSWORD', 'mypassword')
-    helper = OracleDbHelper()
+    helper = DB_HELPER_FACTORY.from_db_params(db_params)
     conn_str = helper.get_sqlalchemy_connection_string(db_params, 'DB_PASSWORD')
-    expected_conn_str = ('oracle://testuser:mypassword@server:1521/testdb')
 
-    assert conn_str == expected_conn_str
-
-
-def test_sqlserver_sqlalchemy_connect(monkeypatch):
-    db_params = DbParams(dbtype='MSSQL',
-                         host='server', port='1521', dbname='testdb',
-                         username='testuser', odbc_driver='test driver')
-    monkeypatch.setenv('DB_PASSWORD', 'mypassword')
-    helper = SqlServerDbHelper()
-    conn_str = helper.get_sqlalchemy_connection_string(db_params, 'DB_PASSWORD')
-    expected_conn_str = 'mssql+pyodbc://testuser:mypassword@server:1521/testdb?driver=test+driver'
-
-    assert conn_str == expected_conn_str
-
-
-def test_postgres_sqlalchemy_connect(monkeypatch):
-    db_params = DbParams(dbtype='PG',
-                         host='server', port='1521', dbname='testdb',
-                         username='testuser')
-    monkeypatch.setenv('DB_PASSWORD', 'mypassword')
-    helper = PostgresDbHelper()
-    conn_str = helper.get_sqlalchemy_connection_string(db_params, 'DB_PASSWORD')
-    expected_conn_str = 'postgresql://testuser:mypassword@server:1521/testdb'
-
-    assert conn_str == expected_conn_str
+    assert conn_str == expected

--- a/test/unit/test_db_helpers.py
+++ b/test/unit/test_db_helpers.py
@@ -11,21 +11,18 @@ from etlhelper import DbParams
 from etlhelper.db_helper_factory import DB_HELPER_FACTORY
 from etlhelper.db_helpers import (
     OracleDbHelper,
-    SqlServerDbHelper,
-    PostgresDbHelper,
-    SQLiteDbHelper
 )
 
 # pylint: disable=missing-docstring
 
 ORACLEDB = DbParams(dbtype='ORACLE', host='server', port='1521',
-                    dbname='testdb', username='testuser')
+                    dbname='testdb', user='testuser')
 
 MSSQLDB = DbParams(dbtype='MSSQL', host='server', port='1521', dbname='testdb',
-                   username='testuser', odbc_driver='test driver')
+                   user='testuser', odbc_driver='test driver')
 
 POSTGRESDB = DbParams(dbtype='PG', host='server', port='1521', dbname='testdb',
-                      username='testuser', odbc_driver='test driver')
+                      user='testuser', odbc_driver='test driver')
 
 SQLITEDB = DbParams(dbtype='SQLITE', filename='/myfile.db')
 


### PR DESCRIPTION
SQLite databases have different connection string syntax and cursors to
previous database types.  To incorporate this:

+ DbHelper now has cursor() method to allow modified SQLite cursor,
which can be used as context manager, to be returned
+ etl functions user helper.cursor() to obtain a cursor
+ password_variable is now optional on connect methods

Unit tests for database helpers were also refactored for clarity.

### To test:

+ [ ] Use an IPython session to create a SQLite database of your own and run queries against it
+ [ ] Confirm that unit and integration tests run


Closes #4