### PR TITLE
Logging test fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,7 @@ test:
         -e TEST_MSSQL_PORT="${TEST_MSSQL_PORT}" \
         -e TEST_MSSQL_DBNAME="${TEST_MSSQL_DBNAME}" \
         -e TEST_MSSQL_PASSWORD="${TEST_MSSQL_PASSWORD}" \
-        "$CI_REGISTRY_IMAGE:test-runner" pytest -rsx --cov=etlhelper -vs test/
+        "$CI_REGISTRY_IMAGE:test-runner" pytest -rsx --cov=etlhelper -vvs test/
 
 package:
   tags:

--- a/test/integration/etl/test_etl_logging.py
+++ b/test/integration/etl/test_etl_logging.py
@@ -30,7 +30,7 @@ INFO_AND_DEBUG = [
     'against\n'
     '\n'
     "<connection object at ???; dsn: 'user=etlhelper_user password=xxx "
-    "dbname=etlhelper host=localhost port=5432', closed: 0>",
+    "dbname=etlhelper host=??? port=5432', closed: 0>",
     'Fetching rows',
     'Fetching:\n'
     '\n'
@@ -43,7 +43,7 @@ INFO_AND_DEBUG = [
     'against\n'
     '\n'
     "<connection object at ???; dsn: 'user=etlhelper_user password=xxx "
-    "dbname=etlhelper host=localhost port=5432', closed: 0>",
+    "dbname=etlhelper host=??? port=5432', closed: 0>",
     "First row: Row(id=1, value=1.234, simple_text='text', utf8_text='Öæ°\\nz', "
     'day=datetime.date(2018, 12, 7), date_time=datetime.datetime(2018, 12, 7, 13, '
     '1, 59))',
@@ -70,9 +70,12 @@ def test_logging_copy_rows(caplog, level, expected,
 
     # Act
     copy_rows(select_sql, pgtestdb_conn, insert_sql, pgtestdb_conn)
-    # ID for connection object varies between tests
+    # ID for connection object and hostname vary between tests
+    # and test environments
     messages = [re.sub(r'object at .*;', 'object at ???;', m)
                 for m in caplog.messages]
+    messages = [re.sub(r'host=.*? ', 'host=??? ', m)
+                for m in messages]
 
     # Assert
     for i, message in enumerate(messages):
@@ -93,7 +96,7 @@ INFO_AND_DEBUG_EXECUTE = [
     'against\n'
     '\n'
     "<connection object at ???; dsn: 'user=etlhelper_user password=xxx "
-    "dbname=etlhelper host=localhost port=5432', closed: 0>"]
+    "dbname=etlhelper host=??? port=5432', closed: 0>"]
 
 
 @pytest.mark.parametrize('level, expected', [
@@ -108,9 +111,12 @@ def test_logging_execute(caplog, level, expected, pgtestdb_conn):
 
     # Act
     execute(select_sql, pgtestdb_conn)
-    # ID for connection object varies between tests
+    # ID for connection object and hostname vary between tests
+    # and test environments
     messages = [re.sub(r'object at .*;', 'object at ???;', m)
                 for m in caplog.messages]
+    messages = [re.sub(r'host=.*? ', 'host=??? ', m)
+                for m in messages]
 
     # Assert
     for i, message in enumerate(messages):


### PR DESCRIPTION
### Description

The logging improvements added in #9 were merged but they failed the tests in GitLab CI.  This is because the host for the database server used in the integration tests was IP address instead of being `localhost`.  The resulting log messages did not match.

This PR fixes the tests so that they replace the hostname recorded in the logs with ??? and updates the expected text string accordingly.

### To test

You can't really test this, but if you look in the GitLab CI logs you can see that the pipeline on the `verbose-tests` branch passed.  This is the same code as the current branch.