### PR TITLE
Automate releases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,4 +83,4 @@ pypi:
   script:
     - pip install -U twine
     - LATEST_RELEASE=$(ls -t dist | head -n 1)
-    - twine upload dist/"${LATEST_RELEASE}"
+    - twine upload --verbose dist/"${LATEST_RELEASE}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,3 +84,5 @@ pypi:
     - pip install -U twine
     - LATEST_RELEASE=$(ls -t dist | head -n 1)
     - twine upload --verbose dist/"${LATEST_RELEASE}" -u $TWINE_USERNAME -p $TWINE_PASSWORD
+  only:
+    - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,3 +86,4 @@ pypi:
     - twine upload --verbose dist/"${LATEST_RELEASE}" -u $TWINE_USERNAME -p $TWINE_PASSWORD
   only:
     - tags
+  when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,4 +83,4 @@ pypi:
   script:
     - pip install -U twine
     - LATEST_RELEASE=$(ls -t dist | head -n 1)
-    - twine upload --verbose dist/"${LATEST_RELEASE}"
+    - twine upload --verbose dist/"${LATEST_RELEASE}" -u $TWINE_USERNAME -p $TWINE_PASSWORD

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ variables:
 stages:
   - test
   - package
+  - release
 
 services:
   - docker:18-dind
@@ -77,6 +78,7 @@ package:
       - dist/
 
 pypi:
+  image: python:3.6-slim
   stage: release
   script:
     - pip install -U twine

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,3 +75,10 @@ package:
   artifacts:
     paths:
       - dist/
+
+pypi:
+  stage: release
+  script:
+    - pip install -U twine
+    - LATEST_RELEASE=$(ls -t dist | head -n 1)
+    - twine upload dist/"${LATEST_RELEASE}"


### PR DESCRIPTION
Automates the release cycle (though with a final manual step on gitlab until the issue of having

```
only:
 - tags
 - master
```

is resolved.