### PR TITLE
Add Python 3.8 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - '3.6'
   - '3.7'
+  - '3.8'
 
 install:
   - sudo apt-get update


### PR DESCRIPTION
tests on the latest stable version of Python