### PR TITLE
Add copy() function to DbParams

### DIFF
--- a/etlhelper/db_params.py
+++ b/etlhelper/db_params.py
@@ -96,6 +96,14 @@ class DbParams(dict):
         finally:
             s.close()
 
+    def copy(self):
+        """
+        Return a shallow copy of DbParams object.
+
+        :return DbParams: DbParams object with same attributes as original.
+        """
+        return self.__class__(**self)
+
     def __repr__(self):
         key_val_str = ", ".join([f"{key}='{self[key]}'" for key in self.keys()])
         return f"DbParams({key_val_str})"

--- a/etlhelper/db_params.py
+++ b/etlhelper/db_params.py
@@ -75,6 +75,12 @@ class DbParams(dict):
         return cls(**dbparams_from_env)
 
     def is_reachable(self):
+        """
+        Test whether network allows opening of tcp/ip connection to database. No
+        username or password are required.
+
+        :return bool:
+        """
         items = dict(self.items())
         if items['dbtype'] == 'SQLITE':
             raise ValueError("SQLITE DbParam does not require connection over network")

--- a/test/integration/test_dbparams.py
+++ b/test/integration/test_dbparams.py
@@ -1,7 +1,11 @@
+"""Tests for db_params that require a database connection."""
+from copy import copy
 import pytest
 
 from etlhelper import DbParams
 from ..conftest import PGTESTDB
+
+# pylint: disable=unused-argument, missing-docstring
 
 
 def test_is_reachable():
@@ -9,17 +13,17 @@ def test_is_reachable():
 
 
 def test_is_unreachable():
-    dbparam = PGTESTDB
+    dbparam = copy(PGTESTDB)  # Copy so real PGTESTDB is not modified
     dbparam['port'] = 1
     assert dbparam.is_reachable() is False
 
 
 def test_sqlite_dbparam_not_supported():
-    SQLITEDB = DbParams(
+    sqlitedb = DbParams(
         dbtype='SQLITE',
         filename='sqlite.db',
         dbname='etlhelper',
         user='etlhelper_user')
 
     with pytest.raises(ValueError):
-        SQLITEDB.is_reachable()
+        sqlitedb.is_reachable()

--- a/test/integration/test_dbparams.py
+++ b/test/integration/test_dbparams.py
@@ -1,5 +1,4 @@
 """Tests for db_params that require a database connection."""
-from copy import copy
 import pytest
 
 from etlhelper import DbParams
@@ -13,7 +12,7 @@ def test_is_reachable():
 
 
 def test_is_unreachable():
-    dbparam = copy(PGTESTDB)  # Copy so real PGTESTDB is not modified
+    dbparam = PGTESTDB.copy()  # Copy so real PGTESTDB is not modified
     dbparam['port'] = 1
     assert dbparam.is_reachable() is False
 

--- a/test/unit/test_db_params.py
+++ b/test/unit/test_db_params.py
@@ -60,3 +60,24 @@ def test_db_params_from_environment_not_set(monkeypatch):
     with pytest.raises(ETLHelperDbParamsError,
                        match=r".*environment variable is not set.*"):
         DbParams.from_environment(prefix='TEST_')
+
+
+def test_db_params_copy():
+    """
+    Test db_params can copy themselves.
+    """
+    # Arrange
+    test_params = DbParams(
+        dbtype='PG',
+        host='localhost',
+        port=5432,
+        dbname='etlhelper',
+        user='etlhelper_user')
+
+    # Act
+    test_params2 = test_params.copy()
+
+    # Assert
+    assert test_params2 == test_params
+    assert test_params2 is not test_params
+    assert isinstance(test_params2, DbParams)


### PR DESCRIPTION
### Description

This pull request adds a `copy()` function to DbParams classes.  It overrides the built-in copy function that previously existed as a consequence of DbParams being derived from a dictionary.  That version would return a dictionary; this one returns a DbParams class.

Note: this should only be merged after the `dbparams-fix` branch has been merged as it is built on top of it.

### To test

+ [x] Check tests and output
+ [x] In an IPython session, create a DbParams object, copy it and confirm that it has correct attributes and that modifying it doesn't modify the original.