### PR TITLE
Dbparams copy fix

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -102,16 +102,16 @@ def pgtestdb_params():
     Create DbParams object for test PostGIS database. Override hostname from
     environment variable to allow CI pipeline to use its own database.
     """
-    pg_test_db = PGTESTDB
+    pg_test_db = PGTESTDB.copy()
 
     # Override host and port if defined in environment variable
     host = os.getenv('TEST_PG_HOST', None)
     if host:
-        pg_test_db.host = host
+        pg_test_db.update(host=host)
 
     port = os.getenv('TEST_PG_PORT', None)
     if port:
-        pg_test_db.port = port
+        pg_test_db.update(port=port)
 
     return pg_test_db
 

--- a/test/integration/test_dbparams.py
+++ b/test/integration/test_dbparams.py
@@ -2,17 +2,18 @@
 import pytest
 
 from etlhelper import DbParams
-from ..conftest import PGTESTDB
 
 # pylint: disable=unused-argument, missing-docstring
 
 
-def test_is_reachable():
-    assert PGTESTDB.is_reachable()
+def test_is_reachable(pgtestdb_params):
+    # Use pgtestdb_params here as it changes hostname for CI tests
+    assert pgtestdb_params.is_reachable()
 
 
-def test_is_unreachable():
-    dbparam = PGTESTDB.copy()  # Copy so real PGTESTDB is not modified
+def test_is_unreachable(pgtestdb_params):
+    # Use pgtestdb_params here as it changes hostname for CI tests
+    dbparam = pgtestdb_params.copy()  # Copy so real PGTESTDB is not modified
     dbparam['port'] = 1
     assert dbparam.is_reachable() is False
 


### PR DESCRIPTION
db_params.is_reachable() failed in CI because test postgres database is at postgis and not at localhost.  This merge fixes this by using test fixture testpgdb_params instead.  The fixture was updated as the hostname changing didn't previously work.  Now uses dictionary.update() syntax.

### To test

+ [x] check internal gitlab pipeline to confirm that tests pass
+ [x] run tests locally and confirm they pass