### PR TITLE
29 add fetch methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+bin/setup_local_env.sh

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ returns
 
 Data are accessible via index (`row[4]`) or name (`row.day`).
 
+Other functions are provided to select data.  `fetchone`, `fetchmany` and
+`fetchall` are equivalent to the cursor methods specified in the DBAPI v2.0.
 `dump_rows` passes each row to a function, while `iter_rows` returns
 a generator for looping over results.
 

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ Data are accessible via index (`row[4]`) or name (`row.day`).
 
 Other functions are provided to select data.  `fetchone`, `fetchmany` and
 `fetchall` are equivalent to the cursor methods specified in the DBAPI v2.0.
-`dump_rows` passes each row to a function, while `iter_rows` returns
-a generator for looping over results.
+`dump_rows` passes each row to a function (default is `print`), while `iter_rows`
+returns a generator for looping over results.
 
 #### Copy rows
 

--- a/etlhelper/__init__.py
+++ b/etlhelper/__init__.py
@@ -11,14 +11,17 @@ from etlhelper.etl import (
     dump_rows,
     execute,
     executemany,
+    fetchone,
+    fetchmany,
+    fetchall,
     get_rows,
     iter_chunks,
     iter_rows,
 )
 from etlhelper.connect import (
-    connect, 
+    connect,
     get_connection_string,
-    get_sqlalchemy_connection_string, 
+    get_sqlalchemy_connection_string,
 )
 
 from ._version import get_versions

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -151,7 +151,7 @@ def fetchone(select_query, conn, parameters=(),
                           parameters=parameters, transform=transform))
 
 
-def fetchmany(select_query, conn, parameters=(), size=1,
+def fetchmany(select_query, conn, size=1, parameters=(),
               row_factory=namedtuple_rowfactory, transform=None):
     """
     Get first 'size' results of query as a list.  See iter_rows for details.

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -185,9 +185,7 @@ def fetchall(select_query, conn, parameters=(),
                           parameters=parameters, transform=transform))
 
 
-
-
-def dump_rows(select_query, conn, output_func, parameters=(),
+def dump_rows(select_query, conn, output_func=print, parameters=(),
               row_factory=namedtuple_rowfactory, transform=None):
     """
     Call output_func(row) one-by-one on results of query.  See iter_rows for
@@ -195,15 +193,15 @@ def dump_rows(select_query, conn, output_func, parameters=(),
 
     :param select_query: str, SQL query to execute
     :param conn: dbapi connection
-    :param output_func: function to be called for each row
+    :param output_func: function to be called for each row (default is print)
+    :param parameters: sequence or dict of bind variables to insert in the query
     :param row_factory: function that accepts a cursor and returns a function
                         for parsing each row
-    :param parameters: sequence or dict of bind variables to insert in the query
     :param transform: function that accepts an iterable (e.g. list) of rows and
                       returns an iterable of rows (possibly of different shape)
     """
-    for row in iter_rows(select_query, conn, row_factory=row_factory,
-                         parameters=parameters, transform=transform):
+    for row in iter_rows(select_query, conn, parameters=parameters,
+                         row_factory=row_factory, transform=transform):
         output_func(row)
 
 

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -138,7 +138,9 @@ def get_rows(select_query, conn, parameters=(),
 def fetchone(select_query, conn, parameters=(),
              row_factory=namedtuple_rowfactory, transform=None):
     """
-    Get first result of query.  See iter_rows for details.
+    Get first result of query.  See iter_rows for details.  Note: iter_rows is
+    recommended for looping over rows individually.
+
     :param select_query: str, SQL query to execute
     :param conn: dbapi connection
     :param parameters: sequence or dict of bind variables to insert in the query
@@ -155,6 +157,8 @@ def fetchmany(select_query, conn, size=1, parameters=(),
               row_factory=namedtuple_rowfactory, transform=None):
     """
     Get first 'size' results of query as a list.  See iter_rows for details.
+    Note: iter_chunks is recommended for looping over rows in batches.
+
     :param select_query: str, SQL query to execute
     :param conn: dbapi connection
     :param parameters: sequence or dict of bind variables to insert in the query

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -1,7 +1,7 @@
 """
 Functions for transferring data in and out of databases.
 """
-from itertools import zip_longest
+from itertools import zip_longest, islice
 import logging
 
 from etlhelper.row_factories import namedtuple_rowfactory
@@ -133,6 +133,58 @@ def get_rows(select_query, conn, parameters=(),
     """
     return list(iter_rows(select_query, conn, row_factory=row_factory,
                           parameters=parameters, transform=transform))
+
+
+def fetchone(select_query, conn, parameters=(),
+             row_factory=namedtuple_rowfactory, transform=None):
+    """
+    Get first result of query.  See iter_rows for details.
+    :param select_query: str, SQL query to execute
+    :param conn: dbapi connection
+    :param parameters: sequence or dict of bind variables to insert in the query
+    :param row_factory: function that accepts a cursor and returns a function
+                        for parsing each row
+    :param transform: function that accepts an iterable (e.g. list) of rows and
+                      returns an iterable of rows (possibly of different shape)
+    """
+    return next(iter_rows(select_query, conn, row_factory=row_factory,
+                          parameters=parameters, transform=transform))
+
+
+def fetchmany(select_query, conn, parameters=(), size=1,
+              row_factory=namedtuple_rowfactory, transform=None):
+    """
+    Get first 'size' results of query as a list.  See iter_rows for details.
+    :param select_query: str, SQL query to execute
+    :param conn: dbapi connection
+    :param parameters: sequence or dict of bind variables to insert in the query
+    :param size: number of rows to return (defaults to 1)
+    :param row_factory: function that accepts a cursor and returns a function
+                        for parsing each row
+    :param transform: function that accepts an iterable (e.g. list) of rows and
+                      returns an iterable of rows (possibly of different shape)
+    """
+    return list(islice(iter_rows(select_query, conn, row_factory=row_factory,
+                                 parameters=parameters, transform=transform),
+                       size))
+
+
+def fetchall(select_query, conn, parameters=(),
+             row_factory=namedtuple_rowfactory, transform=None):
+    """
+    Get all results of query as a list.  See iter_rows for details.
+    :param select_query: str, SQL query to execute
+    :param conn: dbapi connection
+    :param parameters: sequence or dict of bind variables to insert in the query
+    :param row_factory: function that accepts a cursor and returns a function
+                        for parsing each row
+    :param transform: function that accepts an iterable (e.g. list) of rows and
+                      returns an iterable of rows (possibly of different shape)
+    """
+    return list(iter_rows(select_query, conn, row_factory=row_factory,
+                          parameters=parameters, transform=transform))
+
+
 
 
 def dump_rows(select_query, conn, output_func, parameters=(),

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -105,9 +105,9 @@ def iter_rows(select_query, conn, parameters=(),
 
     :param select_query: str, SQL query to execute
     :param conn: dbapi connection
+    :param parameters: sequence or dict of bind variables to insert in the query
     :param row_factory: function that accepts a cursor and returns a function
                         for parsing each row
-    :param parameters: sequence or dict of bind variables to insert in the query
     :param transform: function that accepts an iterable (e.g. list) of rows and
                       returns an iterable of rows (possibly of different shape)
     :param read_lob: bool, convert Oracle LOB objects to strings
@@ -125,9 +125,9 @@ def get_rows(select_query, conn, parameters=(),
     Get results of query as a list.  See iter_rows for details.
     :param select_query: str, SQL query to execute
     :param conn: dbapi connection
+    :param parameters: sequence or dict of bind variables to insert in the query
     :param row_factory: function that accepts a cursor and returns a function
                         for parsing each row
-    :param parameters: sequence or dict of bind variables to insert in the query
     :param transform: function that accepts an iterable (e.g. list) of rows and
                       returns an iterable of rows (possibly of different shape)
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 flake8
 ipdb
 ipython
-pytest
+pytest>=4.6
 pytest-cov
 Sphinx
 sphinxcontrib-applehelp

--- a/test/integration/etl/test_etl_extract.py
+++ b/test/integration/etl/test_etl_extract.py
@@ -148,14 +148,14 @@ def test_fetchmany_happy_path(pgtestdb_test_tables, pgtestdb_conn,
                               test_table_data, size):
     sql = "SELECT * FROM src"
     result = fetchmany(sql, pgtestdb_conn, size=size)
-    assert result == test_table_data[:size - 1]
+    assert result == test_table_data[:size]
 
 
 def test_fetchall_happy_path(pgtestdb_test_tables, pgtestdb_conn,
                              test_table_data):
     sql = "SELECT * FROM src"
     result = fetchall(sql, pgtestdb_conn)
-    assert result == test_table_data[0]
+    assert result == test_table_data
 
 
 def test_dump_rows_happy_path(pgtestdb_test_tables, pgtestdb_conn,

--- a/test/integration/etl/test_etl_extract.py
+++ b/test/integration/etl/test_etl_extract.py
@@ -137,7 +137,7 @@ def test_fetchone_happy_path(pgtestdb_test_tables, pgtestdb_conn,
 def test_fetchmany_happy_path(pgtestdb_test_tables, pgtestdb_conn,
                               test_table_data, size):
     sql = "SELECT * FROM src"
-    result = fetchmany(sql, pgtestdb_conn, size=size)
+    result = fetchmany(sql, pgtestdb_conn, size)
     assert result == test_table_data[:size]
 
 

--- a/test/integration/etl/test_etl_extract.py
+++ b/test/integration/etl/test_etl_extract.py
@@ -7,7 +7,8 @@ from unittest.mock import Mock, call
 
 import pytest
 
-from etlhelper import iter_chunks, iter_rows, get_rows, dump_rows, execute
+from etlhelper import (iter_chunks, iter_rows, get_rows, dump_rows, execute,
+                       fetchone, fetchmany, fetchall)
 from etlhelper.etl import ETLHelperExtractError, ETLHelperQueryError
 from etlhelper.row_factories import dict_rowfactory, namedtuple_rowfactory
 
@@ -133,6 +134,28 @@ def test_get_rows_with_parameters(pgtestdb_test_tables, pgtestdb_conn,
     sql = "SELECT * FROM src where ID = %(identifier)s"
     result = get_rows(sql, pgtestdb_conn, parameters={'identifier': 1})
     assert result == [test_table_data[0]]
+
+
+def test_fetchone_happy_path(pgtestdb_test_tables, pgtestdb_conn,
+                             test_table_data):
+    sql = "SELECT * FROM src"
+    result = fetchone(sql, pgtestdb_conn)
+    assert result == test_table_data[0]
+
+
+@pytest.mark.parametrize('size', [1, 3, 1000])
+def test_fetchmany_happy_path(pgtestdb_test_tables, pgtestdb_conn,
+                              test_table_data, size):
+    sql = "SELECT * FROM src"
+    result = fetchmany(sql, pgtestdb_conn, size=size)
+    assert result == test_table_data[:size - 1]
+
+
+def test_fetchall_happy_path(pgtestdb_test_tables, pgtestdb_conn,
+                             test_table_data):
+    sql = "SELECT * FROM src"
+    result = fetchall(sql, pgtestdb_conn)
+    assert result == test_table_data[0]
 
 
 def test_dump_rows_happy_path(pgtestdb_test_tables, pgtestdb_conn,


### PR DESCRIPTION
### Description

This merge request adds the new methods `fetchone`, `fetchmany` and `fetchall` to etlhelper.  This makes it more consistent with the methods on a DBAPI 2 style cursor.  Closes #29.

As part of this development, the integration tests for select methods were updated.  Repeated, similar tests for transform and parameters for `get_rows` and `dump_rows` were consolidated.  `print` was set as the default function to `dump_rows`.

### To test

+ [x] try each of the new functions by hand, including different `size` values for `fetchmany`
+ [x] try `dump_rows` with and without defining an `output_func`