### PR TITLE
Refactor setup script install func

### DIFF
--- a/etlhelper/setup_oracle_client.py
+++ b/etlhelper/setup_oracle_client.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 import os
 from shutil import copyfile, copytree
+import shutil
 import sys
 from textwrap import dedent
 import urllib.request
@@ -82,28 +83,63 @@ def setup_oracle_client(zip_location):
         sys.exit(1)
 
 
-def install_instantclient(zipfile_path, directories):
+def install_instantclient(zipfile_location, install_dir, script_dir, bin_dir):
     """
-    Install Oracle Instant Client files by unzipping zip file (downloading if requrie
+    Install Oracle Instant Client files. by unzipping zip file (downloading if requrie
     """
-    pass
+    #cleanup(install_dir, script_dir, bin_dir)
+    #create_install_dir()
+
+    #zipfile_path = check_or_get_zipfile(zipfile_location)
+    zipfile_path = zipfile_location  # TODO: replace with check_or_get_zipfile
+
+    install_libraries(zipfile_path, install_dir)
+    symlink_libraries(install_dir)
+
+    #write_ld_library_path_export_script(script_dir)
 
 
-def install(zipfile_path, install_dir):
+def install_libraries(zipfile_path, install_dir):
     """
-    Install zipfile contents to install_dir and create symlinks for
-    libclntsh.so and libocci.so.
+    Install zipfile contents to install_dir.
     """
     # Extract all the files
-    zipfile.ZipFile(zipfile_path).extractall(install_dir)
+    shutil.unpack_archive(zipfile_path, extract_dir=install_dir)
 
-    import ipdb; ipdb.set_trace()
     # Files are initially extracted into a subdirectory - copy them out
+    # and remove subdirectory
     subdir = next(install_dir.glob("instantclient_*"))
-    copytree(subdir, install_dir)
+
+    for item in subdir.iterdir():
+        item.rename(item.parent.parent / item.name)
+
+    subdir.rmdir()
 
 
-    pass
+def symlink_libraries(install_dir):
+    """Link specific .so file versions to general name."""
+    # Specific versions of libraries
+    occi = next(install_dir.glob('libocci.so.*.*'))
+    clntsh = next(install_dir.glob('libclntsh.so.*.*'))
+
+    # Link names
+    occi_link = install_dir / 'libocci.so'
+    clntsh_link = install_dir / 'libclntsh.so'
+
+    # Some versions of InstantClient will have a placeholder file
+    # for where the symlink should be, rahter than a symlink.
+    # It must be removed before trying to create a real symlink.
+
+    # unlink(missing_ok=True) would be possible in Python 3.8+
+    if occi_link.exists():
+        occi_link.unlink()
+    if clntsh_link.exists():
+        clntsh_link.unlink()
+
+    # Make links (note Pathlib's reverse syntax)
+    occi_link.symlink_to(occi)
+    clntsh_link.symlink_to(clntsh)
+    logging.debug('Symlinks created for: %s, %s', occi, clntsh)
 
 
 def get_working_dirs():
@@ -135,42 +171,6 @@ def check_status(install_dir, script_dir, bin_dir):
     }
 
     return status
-
-
-def _create_symlinks(instantclient_dir):
-    """Link specific .so file versions to general name."""
-    # Specific versions
-    occi = next(instantclient_dir.glob('libocci.so.*.*'))
-    clntsh = next(instantclient_dir.glob('libclntsh.so.*.*'))
-
-    # General names
-    occi_link = instantclient_dir / 'libocci.so'
-    clntsh_link = instantclient_dir / 'libclntsh.so'
-
-    # Return early if the links already both exist
-    if os.path.islink(occi_link) and os.path.islink(clntsh_link):
-        return
-
-    # Some versions of InstantClient will have a placeholder file
-    # for where the symlink should be, rahter than a symlink.
-    # It must be removed before trying to create a real symlink.
-
-    # unlink(missing_ok=True) would be possible in Python 3.8+
-    # occi_link.unlink(missing_ok=True)
-    # clntsh_link.unlink(missing_ok=True)
-    try:
-        occi_link.unlink()
-    except FileNotFoundError:
-        pass
-    try:
-        clntsh_link.unlink()
-    except FileNotFoundError:
-        pass
-
-    # Make links
-    os.symlink(occi, occi_link)
-    os.symlink(clntsh, clntsh_link)
-    logging.debug('Symlinks created for: %s, %s', occi, clntsh)
 
 
 def _get_instantclient_dir(zipfile_path):

--- a/etlhelper/setup_oracle_client.py
+++ b/etlhelper/setup_oracle_client.py
@@ -4,7 +4,7 @@ import inspect
 import logging
 from pathlib import Path
 import os
-from shutil import copyfile
+from shutil import copyfile, copytree
 import sys
 from textwrap import dedent
 import urllib.request
@@ -86,6 +86,23 @@ def install_instantclient(zipfile_path, directories):
     """
     Install Oracle Instant Client files by unzipping zip file (downloading if requrie
     """
+    pass
+
+
+def install(zipfile_path, install_dir):
+    """
+    Install zipfile contents to install_dir and create symlinks for
+    libclntsh.so and libocci.so.
+    """
+    # Extract all the files
+    zipfile.ZipFile(zipfile_path).extractall(install_dir)
+
+    import ipdb; ipdb.set_trace()
+    # Files are initially extracted into a subdirectory - copy them out
+    subdir = next(install_dir.glob("instantclient_*"))
+    copytree(subdir, install_dir)
+
+
     pass
 
 

--- a/test/integration/test_setup_oracle_client.py
+++ b/test/integration/test_setup_oracle_client.py
@@ -1,7 +1,23 @@
 """Tests for setup_oracle_client.py script."""
+from etlhelper.setup_oracle_client import install
 
 
 def test_dummy_zipfile(dummy_zipfile):
     assert dummy_zipfile.exists()
     assert dummy_zipfile.is_file()
     assert dummy_zipfile.name == 'instantclient.zip'
+
+
+def test_install(dummy_zipfile, tmp_path):
+    install_dir = tmp_path / 'oracle_instantclient'
+
+    # Act
+    install(dummy_zipfile, install_dir)
+
+    # Assert driver files are present
+    assert list(install_dir.glob('libocci.so.*.*')) != []
+    assert list(install_dir.glob('libclntsh.so.*.*')) != []
+
+    # Assert symlinks are created
+    assert install_dir.joinpath('libocci.so').is_symlink()
+    assert install_dir.joinpath('libclntsh.so').is_symlink()

--- a/test/integration/test_setup_oracle_client.py
+++ b/test/integration/test_setup_oracle_client.py
@@ -1,5 +1,5 @@
 """Tests for setup_oracle_client.py script."""
-from etlhelper.setup_oracle_client import install
+from etlhelper.setup_oracle_client import install_instantclient
 
 
 def test_dummy_zipfile(dummy_zipfile):
@@ -8,11 +8,11 @@ def test_dummy_zipfile(dummy_zipfile):
     assert dummy_zipfile.name == 'instantclient.zip'
 
 
-def test_install(dummy_zipfile, tmp_path):
+def test_install_instantclient(dummy_zipfile, tmp_path):
     install_dir = tmp_path / 'oracle_instantclient'
 
     # Act
-    install(dummy_zipfile, install_dir)
+    install_instantclient(dummy_zipfile, install_dir, None, None)
 
     # Assert driver files are present
     assert list(install_dir.glob('libocci.so.*.*')) != []


### PR DESCRIPTION
This merge request adds functions for `install_libraries` and `symlink_libraries`.  It also stubs out an `install_instantclient` function based on the pseudocode in Issue #2.

There is an integration test to prove that they work.  This test runs against `install_instantclient` and should be extended as each of the sub-functions are fleshed out.

Note that I have tried to use Pathlib where possible for file operations.  It seems like a good way to go.