### PR TITLE
Fixes for dockerised tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ ARG INSTANT_CLIENT_ZIP
 RUN python -m pip install .
 RUN setup_oracle_client ${INSTANT_CLIENT_ZIP} --log DEBUG
 # Have to hard-code oracle_lib_export as ENV can't use result of command
-ENV LD_LIBRARY_PATH=/app/etlhelper/oracle_instantclient/instantclient_12_2
+ENV LD_LIBRARY_PATH=/app/etlhelper/oracle_instantclient

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,6 @@ RUN find . -regextype posix-egrep -regex '.*/__pycache__.*' -delete
 # Set up Oracle Client
 ARG INSTANT_CLIENT_ZIP
 RUN python -m pip install .
-RUN setup_oracle_client ${INSTANT_CLIENT_ZIP}
+RUN setup_oracle_client ${INSTANT_CLIENT_ZIP} --log DEBUG
 # Have to hard-code oracle_lib_export as ENV can't use result of command
 ENV LD_LIBRARY_PATH=/app/etlhelper/oracle_instantclient/instantclient_12_2

--- a/bin/run_tests_for_developer.sh
+++ b/bin/run_tests_for_developer.sh
@@ -1,12 +1,11 @@
 #! /bin/sh
+echo "Flake8 checks"
+flake8 etlhelper test || exit 1
+
 echo "Building container"
 docker build \
   --build-arg INSTANT_CLIENT_ZIP=${INSTANT_CLIENT_ZIP} \
   -t etlhelper-test-runner . || exit 1
-
-echo "Flake8 checks"
-docker run \
-  etlhelper-test-runner flake8 etlhelper test || exit 1
 
 echo "Unit and integration tests"
 docker run \
@@ -25,8 +24,9 @@ docker run \
   -e TEST_MSSQL_PASSWORD="${TEST_MSSQL_PASSWORD}" \
   --net=host \
   --name=etlhelper-test-runner \
+  -it \
   etlhelper-test-runner \
-  pytest -vs -rsx --cov=etlhelper --cov-report html --cov-report term test/
+  pytest -vs -rsx --pdb --cov=etlhelper --cov-report html --cov-report term test/
 
 # Copy coverage files out of container to local if tests passed
 if [ $? -eq 0 ]; then

--- a/etlhelper/setup_oracle_client.py
+++ b/etlhelper/setup_oracle_client.py
@@ -359,7 +359,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Install Oracle Instant Client to Python environment")
     parser.add_argument(
-        '--zip_location', type=str, default='',
+        'zip_location', type=str, nargs='*',
         help="Path or URL of instantclient-*-linux-*.zip")
     parser.add_argument(
         "--log", dest="log_level", default='INFO',
@@ -367,10 +367,17 @@ def main():
         help="Set the logging level")
     args = parser.parse_args()
 
+    # This syntax is used to maintain backwards compatiblity and to make
+    # zip_location optional but without requiring a flag e.g. --zip_location
+    if args.zip_location:
+        zip_location = args.zip_location[0]
+    else:
+        zip_location = ''
+
     if args.log_level:
         logging.getLogger().setLevel(getattr(logging, args.log_level))
 
-    setup_oracle_client(args.zip_location)
+    setup_oracle_client(zip_location)
 
 
 if __name__ == '__main__':

--- a/etlhelper/setup_oracle_client.py
+++ b/etlhelper/setup_oracle_client.py
@@ -223,7 +223,7 @@ def _install_libraries(zipfile_path, install_dir):
     Install zipfile contents to install_dir.
     """
     # Extract all the files
-    shutil.unpack_archive(zipfile_path, extract_dir=install_dir)
+    shutil.unpack_archive(str(zipfile_path), extract_dir=install_dir)
 
     # Files are initially extracted into a subdirectory - copy them out
     # and remove subdirectory

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     slow: mark a test as taking a long time to run.
+addopts = --pdbcls=IPython.terminal.debugger:Pdb

--- a/test/integration/db/test_oracle.py
+++ b/test/integration/db/test_oracle.py
@@ -63,7 +63,7 @@ INSERT_SQL = dedent("""
 
 @pytest.fixture(scope='function')
 def testdb_conn():
-    """Get connection to test MS SQL database."""
+    """Get connection to test Oracle database."""
     with connect(ORADB, 'TEST_ORACLE_PASSWORD', encoding="UTF-8",
                  nencoding="UTF-8") as conn:
         yield conn

--- a/test/integration/test_setup_oracle_client.py
+++ b/test/integration/test_setup_oracle_client.py
@@ -103,7 +103,9 @@ def mock_installation(tmp_path):
     (install_dir / 'libclntsh.so').symlink_to(libclntsh_19)
 
     # Script files
-    script_dir.joinpath('oracle_lib_path_export').touch()
-    bin_dir.joinpath('oracle_lib_path_export').touch()
+    path_export_script = script_dir.joinpath('oracle_lib_path_export')
+    path_export_script.touch()
+    path_export_script_link = bin_dir.joinpath('oracle_lib_path_export')
+    path_export_script_link.symlink_to(path_export_script)
 
     return mock_installation

--- a/test/unit/test_setup_oracle_client.py
+++ b/test/unit/test_setup_oracle_client.py
@@ -44,6 +44,7 @@ def test_oracle_client_is_configured(monkeypatch, caplog, emsg, expected_return,
     if caplog.record_tuples:
         assert caplog.record_tuples[-1][2] == expected_text
 
+
 @pytest.mark.parametrize("emsg, expected_text",
                          [("DPI-1047: libnsl.so.1", NSL_MESSAGE),
                           ("DPI-9999: Some weird error",


### PR DESCRIPTION
This merge request makes the zip_location an optional parameter without it necessarily being named.  This makes the syntax compatible with the previous versions so that Dockerised tests work.  Making this change revealed problems with the code that were only visible when running the full integration test suite.  These changes were made now.

Note that our new install script will break CI pipelines because the LD_LIBRARY_PATH that drivers are installed to is different.  This path is hard-coded into various Docker containers.

This merge contributes to #2 