### PR TITLE
Reinstall option flag

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    etlhelper/_version.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY requirements.txt $APP/
 RUN pip install -r requirements.txt
 
 # Copy app files to container
-COPY setup.py versioneer.py setup.cfg .flake8 README.md pytest.ini $APP/
+COPY setup.py versioneer.py setup.cfg .flake8 .coveragerc README.md pytest.ini $APP/
 COPY etlhelper/ $APP/etlhelper
 COPY test/ $APP/test
 

--- a/etlhelper/setup_oracle_client.py
+++ b/etlhelper/setup_oracle_client.py
@@ -22,7 +22,7 @@ logging.basicConfig(handlers=[handler], level=logging.INFO)
 ORACLE_DEFAULT_ZIP_URL = ("https://download.oracle.com/otn_software/linux/instantclient/instantclient-basiclite-linuxx64.zip")  # noqa
 
 
-def setup_oracle_client(zip_location):
+def setup_oracle_client(zip_location, reinstall=False):
     """
     Install and configure Oracle Instant Client.  The function will:
         + download Oracle libraries from internet or custom URL if required
@@ -32,11 +32,12 @@ def setup_oracle_client(zip_location):
         + print the name of the script to <stdout>
 
     :param zip_location: str, URL or local file path of instantclient zip file
+    :param reinstall: bool, reinstall option
     """
     install_dir, ld_library_prepend_script = _get_install_paths()
 
     # Return if configured already
-    if _oracle_client_is_configured():
+    if _oracle_client_is_configured() and not reinstall:
         logging.info('Oracle Client library is correctly configured')
         print(ld_library_prepend_script.absolute())
         return
@@ -52,8 +53,7 @@ def setup_oracle_client(zip_location):
                                               ld_library_prepend_script)
 
     # Install if required
-    # TODO: Add reinstall option
-    if not already_installed:
+    if not already_installed or reinstall:
         _install_instantclient(zip_location, install_dir,
                                ld_library_prepend_script)
 
@@ -343,6 +343,9 @@ def main():
     parser.add_argument(
         "-v", "--verbose", help="print debug-level logging output",
         action="store_true")
+    parser.add_argument(
+        "--reinstall", dest="reinstall", action="store_true",
+        help="Reinstall the client, whether already installed or not")
     args = parser.parse_args()
 
     if args.zip_location:
@@ -353,7 +356,7 @@ def main():
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
-    setup_oracle_client(zip_location)
+    setup_oracle_client(zip_location, reinstall=args.reinstall)
 
 
 if __name__ == '__main__':

--- a/etlhelper/setup_oracle_client.py
+++ b/etlhelper/setup_oracle_client.py
@@ -293,10 +293,10 @@ WINDOWS_INSTALL_MESSAGE = dedent("""
     https://www.oracle.com/technetwork/database/database-technologies/instant-client/downloads/index.html
     """).strip() + '\n'
 
-CLNTSH_MESSAGE = dedent("""
-    Oracle Instant Client library (libclntsh.so) is not on LD_LIBRARY_PATH or
-    libclntsh.so is a placeholder and a symlink must be created first.
-    """).strip()
+CLNTSH_MESSAGE = (
+    "Oracle Instant Client library (libclntsh.so) is not on LD_LIBRARY_PATH or "
+    "libclntsh.so is a placeholder and a symlink must be created first."
+    )
 
 NSL_MESSAGE = dedent("""
     The Network Services Library, libnsl.so.1, could not be found.

--- a/test/integration/test_setup_oracle_client.py
+++ b/test/integration/test_setup_oracle_client.py
@@ -53,6 +53,23 @@ def test_check_install_status_installed(mock_installation):
     assert already_installed
 
 
+def test_check_install_status_empty_install_dir(mock_installation):
+    # Arrange
+    install_dir = mock_installation / 'install'
+    ld_library_prepend_script = install_dir / 'ld_library_prepend.sh'
+
+    # Remove every item in the install_dir to simulate empty install_dir
+    for item in install_dir.iterdir():
+        item.unlink()
+
+    # Act
+    already_installed = _check_install_status(install_dir,
+                                              ld_library_prepend_script)
+
+    # Assert
+    assert already_installed is False
+
+
 def test_check_install_status_no_links(mock_installation):
     # Arrange
     install_dir = mock_installation / 'install'

--- a/test/unit/test_setup_oracle_client.py
+++ b/test/unit/test_setup_oracle_client.py
@@ -1,12 +1,12 @@
 """Unit tests for setup_oracle_client."""
 import logging
 import sys
-import cx_Oracle
+from unittest.mock import MagicMock, Mock
 
+import cx_Oracle
 from cx_Oracle import DatabaseError, _Error
 import pytest
 
-from unittest.mock import MagicMock, Mock
 import etlhelper.setup_oracle_client as soc
 from etlhelper.setup_oracle_client import (
     setup_oracle_client,

--- a/test/unit/test_setup_oracle_client.py
+++ b/test/unit/test_setup_oracle_client.py
@@ -100,7 +100,7 @@ def test_cmd_line_arguments(monkeypatch):
     monkeypatch.setattr(
         sys, 'argv',
         ['setup_oracle_client', '-z',
-         'http://python.glpages.ad.nerc.ac.uk/bgs_etl/instantclient-basic-linux.x64-12.2.0.1.0.zip',
+         'http://dummypath',
          '--reinstall', '-v'])
 
     # Act (call main from the soc module)
@@ -108,5 +108,23 @@ def test_cmd_line_arguments(monkeypatch):
 
     # Assert
     mock_setup_oracle_client_function.assert_called_with(
-        'http://python.glpages.ad.nerc.ac.uk/bgs_etl/instantclient-basic-linux.x64-12.2.0.1.0.zip',
+        'http://dummypath',
         reinstall=True)
+
+
+def test_cmd_line_arguments_defaults(monkeypatch):
+    """Test that cmd line args use defaults if not specified."""
+    # Arrange
+    mock_setup_oracle_client_function = Mock()
+    monkeypatch.setattr(soc, 'setup_oracle_client', mock_setup_oracle_client_function)
+    monkeypatch.setattr(
+        sys, 'argv',
+        ['setup_oracle_client'])
+
+    # Act (call main from the soc module)
+    soc.main()
+
+    # Assert
+    mock_setup_oracle_client_function.assert_called_with(
+        soc.ORACLE_DEFAULT_ZIP_URL,
+        reinstall=False)

--- a/test/unit/test_setup_oracle_client.py
+++ b/test/unit/test_setup_oracle_client.py
@@ -1,11 +1,12 @@
 """Unit tests for setup_oracle_client."""
 import logging
+import sys
 import cx_Oracle
 
 from cx_Oracle import DatabaseError, _Error
 import pytest
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 import etlhelper.setup_oracle_client as soc
 from etlhelper.setup_oracle_client import (
     setup_oracle_client,
@@ -89,3 +90,17 @@ def test_reinstall_installed_not_configured(monkeypatch, client_config_status, i
 
     # Assert
     mock_install_instant_client.assert_called_once()
+
+
+def test_cmd_line_arguments(monkeypatch):
+    """Test that cmd line args trigger the right bit of code logic when called"""
+    # Arrange
+    mock_setup_oracle_client_function = Mock()
+    monkeypatch.setattr(soc, 'setup_oracle_client', mock_setup_oracle_client_function)
+    monkeypatch.setattr(sys, 'argv', ['setup_oracle_client', '-z', 'http://python.glpages.ad.nerc.ac.uk/bgs_etl/instantclient-basic-linux.x64-12.2.0.1.0.zip', '--reinstall', '-v'])
+
+    # Act (call main from the soc module)
+    soc.main()
+
+    # Assert
+    mock_setup_oracle_client_function.assert_called_with('http://python.glpages.ad.nerc.ac.uk/bgs_etl/instantclient-basic-linux.x64-12.2.0.1.0.zip', reinstall=True)

--- a/test/unit/test_setup_oracle_client.py
+++ b/test/unit/test_setup_oracle_client.py
@@ -97,10 +97,16 @@ def test_cmd_line_arguments(monkeypatch):
     # Arrange
     mock_setup_oracle_client_function = Mock()
     monkeypatch.setattr(soc, 'setup_oracle_client', mock_setup_oracle_client_function)
-    monkeypatch.setattr(sys, 'argv', ['setup_oracle_client', '-z', 'http://python.glpages.ad.nerc.ac.uk/bgs_etl/instantclient-basic-linux.x64-12.2.0.1.0.zip', '--reinstall', '-v'])
+    monkeypatch.setattr(
+        sys, 'argv',
+        ['setup_oracle_client', '-z',
+         'http://python.glpages.ad.nerc.ac.uk/bgs_etl/instantclient-basic-linux.x64-12.2.0.1.0.zip',
+         '--reinstall', '-v'])
 
     # Act (call main from the soc module)
     soc.main()
 
     # Assert
-    mock_setup_oracle_client_function.assert_called_with('http://python.glpages.ad.nerc.ac.uk/bgs_etl/instantclient-basic-linux.x64-12.2.0.1.0.zip', reinstall=True)
+    mock_setup_oracle_client_function.assert_called_with(
+        'http://python.glpages.ad.nerc.ac.uk/bgs_etl/instantclient-basic-linux.x64-12.2.0.1.0.zip',
+        reinstall=True)


### PR DESCRIPTION
# Summary 

Adds a `--reinstall` optional flag that reinstalls the Oracle drivers, for example to deal with an aborted installation or to force a reinstall, or to install a different version of the already installed drivers. Extra tests in test suite to verify behaviour. 

Closes #2, #54, #60

## To test

 - [x] Install the software as usual.
 - [x] Attempt to reinstall again with the `--reinstall` flag option.
 - [x] Confirm new unit and integration tests are working/look sensible