### PR TITLE
Replace rowfactory with row_factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,15 +337,15 @@ For example, to return each row as a dictionary, use the following:
 
 ```python
 from etlhelper import connect, iter_rows
-from etlhelper.row_factories import dict_rowfactory
+from etlhelper.row_factories import dict_row_factory
 
 conn = connect(ORACLEDB, 'ORACLE_PASSWORD')
 sql = "SELECT * FROM my_table"
-for row in iter_rows(sql, conn, row_factory=dict_rowfactory):
+for row in iter_rows(sql, conn, row_factory=dict_row_factory):
     print(row['id'])
 ```
 
-The `dict_rowfactory` is useful when getting data to be serialised
+The `dict_row_factory` is useful when getting data to be serialised
 into JSON.
 When combined with [Hug](http://pypi.org/project/hug), an HTTP API can be
 created in fewer than 20 lines of code.

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -5,7 +5,7 @@ from itertools import zip_longest, islice
 import logging
 from warnings import warn
 
-from etlhelper.row_factories import namedtuple_rowfactory
+from etlhelper.row_factories import namedtuple_row_factory
 from etlhelper.db_helper_factory import DB_HELPER_FACTORY
 from etlhelper.exceptions import (
     ETLHelperExtractError,
@@ -20,14 +20,14 @@ CHUNKSIZE = 5000
 # iter_chunks is where data are retrieved from source database
 # All data extraction processes call this function.
 def iter_chunks(select_query, conn, parameters=(),
-                row_factory=namedtuple_rowfactory,
+                row_factory=namedtuple_row_factory,
                 transform=None, read_lob=False):
     """
     Run SQL query against connection and return iterator object to loop over
     results in batches of etlhelper.etl.CHUNKSIZE (default 5000).
 
     The row_factory changes the output format of the results.  Other row
-    factories e.g. dict_rowfactory are available.
+    factories e.g. dict_row_factory are available.
 
     The transform function is applied to chunks of data as they are extracted
     from the database.
@@ -98,7 +98,7 @@ def iter_chunks(select_query, conn, parameters=(),
 
 
 def iter_rows(select_query, conn, parameters=(),
-              row_factory=namedtuple_rowfactory,
+              row_factory=namedtuple_row_factory,
               transform=None, read_lob=False):
     """
     Run SQL query against connection and return iterator object to loop over
@@ -121,7 +121,7 @@ def iter_rows(select_query, conn, parameters=(),
 
 
 def get_rows(select_query, conn, parameters=(),
-             row_factory=namedtuple_rowfactory, transform=None):
+             row_factory=namedtuple_row_factory, transform=None):
     """
     Get results of query as a list.  See iter_rows for details.
     :param select_query: str, SQL query to execute
@@ -137,7 +137,7 @@ def get_rows(select_query, conn, parameters=(),
 
 
 def fetchone(select_query, conn, parameters=(),
-             row_factory=namedtuple_rowfactory, transform=None):
+             row_factory=namedtuple_row_factory, transform=None):
     """
     Get first result of query.  See iter_rows for details.  Note: iter_rows is
     recommended for looping over rows individually.
@@ -155,7 +155,7 @@ def fetchone(select_query, conn, parameters=(),
 
 
 def fetchmany(select_query, conn, size=1, parameters=(),
-              row_factory=namedtuple_rowfactory, transform=None):
+              row_factory=namedtuple_row_factory, transform=None):
     """
     Get first 'size' results of query as a list.  See iter_rows for details.
     Note: iter_chunks is recommended for looping over rows in batches.
@@ -175,7 +175,7 @@ def fetchmany(select_query, conn, size=1, parameters=(),
 
 
 def fetchall(select_query, conn, parameters=(),
-             row_factory=namedtuple_rowfactory, transform=None):
+             row_factory=namedtuple_row_factory, transform=None):
     """
     Get all results of query as a list.  See iter_rows for details.
     :param select_query: str, SQL query to execute
@@ -191,7 +191,7 @@ def fetchall(select_query, conn, parameters=(),
 
 
 def dump_rows(select_query, conn, output_func=print, parameters=(),
-              row_factory=namedtuple_rowfactory, transform=None):
+              row_factory=namedtuple_row_factory, transform=None):
     """
     Call output_func(row) one-by-one on results of query.  See iter_rows for
     details.

--- a/etlhelper/row_factories.py
+++ b/etlhelper/row_factories.py
@@ -14,7 +14,7 @@ from warnings import warn
 import re
 
 
-def namedtuple_rowfactory(cursor):
+def namedtuple_row_factory(cursor):
     """Return output as a named tuple"""
     column_names = [d[0] for d in cursor.description]
 
@@ -26,7 +26,7 @@ def namedtuple_rowfactory(cursor):
         warn("One or more columns have been renamed. Names that cannot be "
              "converted to namedtuple attributes are replaced by indices. To "
              "prevent column renaming, either provide alias in SQL query, "
-             "e.g. 'SELECT count(*) AS c', or use dict_rowfactory. ")
+             "e.g. 'SELECT count(*) AS c', or use dict_row_factory. ")
         warn(f"{renamed_columns}")
 
     def create_row(row):
@@ -35,7 +35,7 @@ def namedtuple_rowfactory(cursor):
     return create_row
 
 
-def dict_rowfactory(cursor):
+def dict_row_factory(cursor):
     """Replace the default tuple output with a dict"""
     column_names = [d[0] for d in cursor.description]
 

--- a/test/integration/etl/test_etl_extract.py
+++ b/test/integration/etl/test_etl_extract.py
@@ -11,7 +11,7 @@ import etlhelper.etl as etlhelper_etl
 from etlhelper import (iter_chunks, iter_rows, get_rows, dump_rows, execute,
                        fetchone, fetchmany, fetchall)
 from etlhelper.etl import ETLHelperExtractError, ETLHelperQueryError
-from etlhelper.row_factories import dict_rowfactory, namedtuple_rowfactory
+from etlhelper.row_factories import dict_row_factory, namedtuple_row_factory
 
 
 @pytest.mark.parametrize('chunk_size, slices', [
@@ -73,7 +73,7 @@ def test_iter_rows_transform(pgtestdb_test_tables, pgtestdb_conn,
 
 def test_iter_rows_dict_factory(pgtestdb_test_tables, pgtestdb_conn):
     sql = "SELECT * FROM src"
-    result = iter_rows(sql, pgtestdb_conn, row_factory=dict_rowfactory)
+    result = iter_rows(sql, pgtestdb_conn, row_factory=dict_row_factory)
     expected = [
         {'id': 1, 'value': 1.234, 'simple_text': 'text', 'utf8_text': 'Öæ°\nz',
          'day': datetime.date(2018, 12, 7),
@@ -92,7 +92,7 @@ def test_iter_rows_dict_factory(pgtestdb_test_tables, pgtestdb_conn):
 def test_iter_rows_namedtuple_factory(
         pgtestdb_test_tables, pgtestdb_conn, test_table_data):
     sql = "SELECT * FROM src"
-    result = iter_rows(sql, pgtestdb_conn, row_factory=namedtuple_rowfactory)
+    result = iter_rows(sql, pgtestdb_conn, row_factory=namedtuple_row_factory)
     row = list(result)[0]
 
     assert row.id == 1
@@ -183,12 +183,12 @@ def test_arguments_passed_to_iter_rows(
     # Act
     # getattr returns fetchmethod, which we call  with given parameters
     # Use real connection parameters to ensure we reach the call to iter_rows
-    # Use dict_rowfactory to demonstrate the default (namedtuple_rowfactory)
+    # Use dict_row_factory to demonstrate the default (namedtuple_row_factory)
     # isn't called
     try:
         getattr(etlhelper_etl, fetchmethod)(sql, pgtestdb_conn,
                                             parameters=parameters,
-                                            row_factory=dict_rowfactory,
+                                            row_factory=dict_row_factory,
                                             transform=transform)
     except TypeError:
         # We expect an error here as the mock_iter_rows breaks the functions
@@ -198,7 +198,7 @@ def test_arguments_passed_to_iter_rows(
     # Assert
     mock_iter_rows.assert_called_once_with(sql, pgtestdb_conn,
                                            parameters=parameters,
-                                           row_factory=dict_rowfactory,
+                                           row_factory=dict_row_factory,
                                            transform=transform)
 
 

--- a/test/unit/test_row_factory.py
+++ b/test/unit/test_row_factory.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from etlhelper.row_factories import namedtuple_rowfactory
+from etlhelper.row_factories import namedtuple_row_factory
 
 
 FAKE_ROWS = [(1, 2, 3), (4, 5, 6)]
@@ -17,7 +17,7 @@ def test_valid_field_names(mock_cursor):
                                ('name', None, None, None, None, None, None),
                                ('desc', None, None, None, None, None, None))
 
-    create_row = namedtuple_rowfactory(mock_cursor)
+    create_row = namedtuple_row_factory(mock_cursor)
     rows = [create_row(row) for row in mock_cursor.fetchall()]
 
     assert rows[0]._fields == ("id", "name", "desc")
@@ -30,7 +30,7 @@ def test_invalid_field_names(mock_cursor):
                                ('spaced column', None, None, None, None, None, None))
 
     with pytest.warns(UserWarning) as warn:
-        create_row = namedtuple_rowfactory(mock_cursor)
+        create_row = namedtuple_row_factory(mock_cursor)
         assert len(warn) == 2
         assert (warn[1].message.args[0]
                 == 'count(*) was renamed to _1\nspaced column was renamed to _2')


### PR DESCRIPTION
### Description

This makes the code consistent internally and with other Python modules
e.g. sqlite3.

This is a breaking change.

Closes #43.

### To test

+ [x] Run a SELECT query against a database and confirm different row_factories work.