### PR TITLE
Change parameter order for executemany

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ rows = [(1, 'value'), (2, 'another value')]
 insert_sql = "INSERT INTO some_table (col1, col2) VALUES (%s, %s)"
 
 with connect(some_db, 'SOME_DB_PASSWORD') as conn:
-    executemany(insert_sql, rows, conn)
+    executemany(insert_sql, conn, rows)
 ```
 
 ## Development

--- a/etlhelper/db_helpers/postgres.py
+++ b/etlhelper/db_helpers/postgres.py
@@ -51,7 +51,7 @@ class PostgresDbHelper(DbHelper):
         :param chunk: list, Rows of parameters.
         """
         # Here we use execute_batch to send multiple inserts to db at once.
-        # This is faster than execute_many() because it results in fewer db
+        # This is faster than executemany() because it results in fewer db
         # calls.  execute_values() or preparing single statement with
         # mogrify() were not used because resulting input statement is less
         # clear and selective formatting of inputs for spatial vs non-spatial

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -3,7 +3,6 @@ Functions for transferring data in and out of databases.
 """
 from itertools import zip_longest, islice
 import logging
-from warnings import warn
 
 from etlhelper.row_factories import namedtuple_rowfactory
 from etlhelper.db_helper_factory import DB_HELPER_FACTORY
@@ -210,7 +209,7 @@ def dump_rows(select_query, conn, output_func=print, parameters=(),
         output_func(row)
 
 
-def executemany(query, rows, conn, commit_chunks=True):
+def executemany(query, conn, rows, commit_chunks=True):
     """
     Use query to insert/update data from rows to database at conn.  This
     method uses the executemany or execute_batch (PostgreSQL) commands to
@@ -224,16 +223,11 @@ def executemany(query, rows, conn, commit_chunks=True):
     which records have been successfully transferred.
 
     :param query: str, SQL insert command with placeholders for data
-    :param rows: List of tuples containing data to be inserted/updated
     :param conn: dbapi connection
+    :param rows: List of tuples containing data to be inserted/updated
     :param commit_chunks: bool, commit after each chunk has been inserted/updated
     :return row_count: int, number of rows inserted/updated
     """
-    msg = ("executemany parameter order will be changed in a future release to "
-           "(query, conn, rows).  "
-           "Avoid breaking code by using named parameters for all e.g. "
-           "executemany(query=my_query, conn=my_conn, rows=my_rows)")
-    warn(msg, DeprecationWarning)
     logger.info(f"Executing many (chunksize={CHUNKSIZE})")
     logger.debug(f"Executing:\n\n{query}\n\nagainst\n\n{conn}")
 
@@ -304,7 +298,7 @@ def copy_rows(select_query, source_conn, insert_query, dest_conn,
     rows_generator = iter_rows(select_query, source_conn,
                                parameters=parameters, transform=transform,
                                read_lob=read_lob)
-    executemany(insert_query, rows_generator, dest_conn,
+    executemany(insert_query, dest_conn, rows_generator,
                 commit_chunks=commit_chunks)
 
 

--- a/test/integration/etl/test_etl_load.py
+++ b/test/integration/etl/test_etl_load.py
@@ -16,7 +16,7 @@ def test_insert_rows_happy_path(pgtestdb_conn, pgtestdb_test_tables,
     insert_sql = pgtestdb_insert_sql.replace('src', 'dest')
 
     # Act
-    executemany(insert_sql, test_table_data, pgtestdb_conn,
+    executemany(insert_sql, pgtestdb_conn, test_table_data,
                 commit_chunks=commit_chunks)
 
     # Assert
@@ -34,7 +34,7 @@ def test_insert_rows_chunked(pgtestdb_conn, pgtestdb_test_tables,
     insert_sql = pgtestdb_insert_sql.replace('src', 'dest')
 
     # Act
-    executemany(insert_sql, test_table_data, pgtestdb_conn)
+    executemany(insert_sql, pgtestdb_conn, test_table_data)
 
     # Assert
     sql = "SELECT * FROM dest"
@@ -48,7 +48,7 @@ def test_insert_rows_no_rows(pgtestdb_conn, pgtestdb_test_tables,
     insert_sql = pgtestdb_insert_sql.replace('src', 'dest')
 
     # Act
-    executemany(insert_sql, [], pgtestdb_conn)
+    executemany(insert_sql, pgtestdb_conn, [])
 
     # Assert
     sql = "SELECT * FROM dest"
@@ -62,4 +62,4 @@ def test_insert_rows_bad_query(pgtestdb_conn, test_table_data):
 
     # Act and assert
     with pytest.raises(ETLHelperInsertError):
-        executemany(insert_sql, test_table_data, pgtestdb_conn)
+        executemany(insert_sql, pgtestdb_conn, test_table_data)


### PR DESCRIPTION
Reversing the parameter order makes executemany(query, conn, rows)
consistent with existing execute(query, conn).

This is a breaking change.

This change extends #28 by updating tests and documentation.