### PR TITLE
Paramstyle fix

### DIFF
--- a/etlhelper/db_helpers/db_helper.py
+++ b/etlhelper/db_helpers/db_helper.py
@@ -14,12 +14,14 @@ class DbHelper(metaclass=ABCMeta):
     """
     sql_exceptions = None
     connect_exceptions = None
+    paramstyle = None
 
     @abstractmethod
     def __init__(self):
         self.sql_exceptions = tuple()
         self.connect_exceptions = tuple()
         self.required_params = set()
+        self.paramstyle = ''
         # Dummy function to allowing calling in connect below
         # (To satisfy Pylint)
         # Throws exception if not overidden

--- a/etlhelper/db_helpers/mssql.py
+++ b/etlhelper/db_helpers/mssql.py
@@ -13,8 +13,9 @@ class MSSQLDbHelper(DbHelper):
         try:
             import pyodbc
             self.sql_exceptions = (pyodbc.DatabaseError)
-            self._connect_func = pyodbc.connect
             self.connect_exceptions = (pyodbc.DatabaseError, pyodbc.InterfaceError)
+            self.paramstyle = pyodbc.paramstyle
+            self._connect_func = pyodbc.connect
             self.required_params = {'host', 'port', 'dbname', 'user', 'odbc_driver'}
         except ImportError:
             print("The pyodc Python package could not be found.\n"

--- a/etlhelper/db_helpers/oracle.py
+++ b/etlhelper/db_helpers/oracle.py
@@ -13,8 +13,9 @@ class OracleDbHelper(DbHelper):
         try:
             import cx_Oracle
             self.sql_exceptions = (cx_Oracle.DatabaseError)
-            self._connect_func = cx_Oracle.connect
             self.connect_exceptions = (cx_Oracle.DatabaseError)
+            self.paramstyle = cx_Oracle.paramstyle
+            self._connect_func = cx_Oracle.connect
             self.required_params = {'host', 'port', 'dbname', 'user'}
         except ImportError:
             print("The cxOracle drivers were not found. See setup guide for more information.")

--- a/etlhelper/db_helpers/postgres.py
+++ b/etlhelper/db_helpers/postgres.py
@@ -13,8 +13,9 @@ class PostgresDbHelper(DbHelper):
         try:
             import psycopg2
             self.sql_exceptions = (psycopg2.ProgrammingError)
-            self._connect_func = psycopg2.connect
             self.connect_exceptions = (psycopg2.OperationalError)
+            self.paramstyle = psycopg2.paramstyle
+            self._connect_func = psycopg2.connect
             self.required_params = {'host', 'port', 'dbname', 'user'}
         except ImportError:
             print("The PostgreSQL python libraries could not be found.\n"

--- a/etlhelper/db_helpers/postgres.py
+++ b/etlhelper/db_helpers/postgres.py
@@ -12,7 +12,9 @@ class PostgresDbHelper(DbHelper):
         super().__init__()
         try:
             import psycopg2
-            self.sql_exceptions = (psycopg2.ProgrammingError)
+            self.sql_exceptions = (psycopg2.ProgrammingError,
+                                   psycopg2.InterfaceError,
+                                   psycopg2.InternalError)
             self.connect_exceptions = (psycopg2.OperationalError)
             self.paramstyle = psycopg2.paramstyle
             self._connect_func = psycopg2.connect

--- a/etlhelper/db_helpers/sqlite.py
+++ b/etlhelper/db_helpers/sqlite.py
@@ -15,8 +15,9 @@ class SQLiteDbHelper(DbHelper):
             import sqlite3
             self.sql_exceptions = (sqlite3.OperationalError,
                                    sqlite3.IntegrityError)
-            self._connect_func = sqlite3.connect
             self.connect_exceptions = (sqlite3.OperationalError)
+            self.paramstyle = sqlite3.paramstyle
+            self._connect_func = sqlite3.connect
             self.required_params = {'filename'}
         except ImportError:
             print("The sqlite3 module was not found. Check configuration as "

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -56,7 +56,8 @@ def iter_chunks(select_query, conn, parameters=(),
             # Even though we haven't modified data, we have to rollback to
             # clear the failed transaction before any others can be started.
             conn.rollback()
-            msg = f"SQL query raised an error.\n\n{select_query}\n\n{exc}\n"
+            msg = (f"SQL query raised an error.\n\n{select_query}\n\n"
+                   f"Required paramstyle: {helper.paramstyle}\n\n{exc}\n")
             raise ETLHelperExtractError(msg)
 
         # Set row factory
@@ -253,7 +254,8 @@ def executemany(query, conn, rows, commit_chunks=True):
                 # Rollback to clear the failed transaction before any others can
                 # be # started.
                 conn.rollback()
-                msg = f"SQL query raised an error.\n\n{query}\n\n{exc}\n"
+                msg = (f"SQL query raised an error.\n\n{query}\n\n"
+                       f"Required paramstyle: {helper.paramstyle}\n\n{exc}\n")
                 raise ETLHelperInsertError(msg)
 
             logger.info(
@@ -324,7 +326,8 @@ def execute(query, conn, parameters=()):
             # Even though we haven't modified data, we have to rollback to
             # clear the failed transaction before any others can be started.
             conn.rollback()
-            msg = f"SQL query raised an error.\n\n{query}\n\n{exc}\n"
+            msg = (f"SQL query raised an error.\n\n{query}\n\n"
+                   f"Required paramstyle: {helper.paramstyle}\n\n{exc}\n")
             raise ETLHelperQueryError(msg)
 
 

--- a/test/integration/db/test_oracle.py
+++ b/test/integration/db/test_oracle.py
@@ -10,7 +10,8 @@ import cx_Oracle
 import pytest
 
 from etlhelper import connect, get_rows, copy_rows, DbParams
-from etlhelper.exceptions import ETLHelperConnectionError
+from etlhelper.exceptions import ETLHelperConnectionError, ETLHelperInsertError
+
 from test.conftest import db_is_unreachable
 
 # Skip these tests if database is unreachable
@@ -51,6 +52,14 @@ def test_copy_rows_happy_path(test_tables, testdb_conn, test_table_data):
         assert result[i] == tuple(row_with_datetimes)
 
 
+def test_copy_rows_bad_param_style(test_tables, testdb_conn, test_table_data):
+    # Arrange and act
+    select_sql = "SELECT * FROM src"
+    insert_sql = BAD_PARAM_STYLE_SQL.format(tablename='dest')
+    with pytest.raises(ETLHelperInsertError):
+        copy_rows(select_sql, testdb_conn, insert_sql, testdb_conn)
+
+
 # -- Fixtures here --
 
 INSERT_SQL = dedent("""
@@ -58,6 +67,14 @@ INSERT_SQL = dedent("""
       day, date_time)
     VALUES
       (:1, :2, :3, :4, :5, :6)
+      """).strip()
+
+
+BAD_PARAM_STYLE_SQL = dedent("""
+    INSERT INTO {tablename} (id, value, simple_text, utf8_text,
+      day, date_time)
+    VALUES
+      (?, ?, ?, ?, ?, ?)
       """).strip()
 
 

--- a/test/integration/db/test_sqlite.py
+++ b/test/integration/db/test_sqlite.py
@@ -11,7 +11,11 @@ from textwrap import dedent
 import pytest
 
 from etlhelper import connect, get_rows, copy_rows, execute, DbParams
-from etlhelper.exceptions import ETLHelperConnectionError, ETLHelperQueryError
+from etlhelper.exceptions import (
+    ETLHelperConnectionError,
+    ETLHelperQueryError,
+    ETLHelperInsertError
+)
 
 
 # -- Tests here --
@@ -75,6 +79,14 @@ def test_copy_rows_happy_path(test_tables, testdb_conn, test_table_data):
     assert fixed == test_table_data
 
 
+def test_copy_rows_bad_param_style(test_tables, testdb_conn, test_table_data):
+    # Arrange and act
+    select_sql = "SELECT * FROM src"
+    insert_sql = BAD_PARAM_STYLE_SQL.format(tablename='dest')
+    with pytest.raises(ETLHelperInsertError):
+        copy_rows(select_sql, testdb_conn, insert_sql, testdb_conn)
+
+
 def test_get_rows_with_parameters(pgtestdb_test_tables, pgtestdb_conn,
                                   test_table_data):
     # parameters=None is tested by default in other tests
@@ -92,6 +104,14 @@ INSERT_SQL = dedent("""
       day, date_time)
     VALUES
       (?, ?, ?, ?, ?, ?)
+      """).strip()
+
+
+BAD_PARAM_STYLE_SQL = dedent("""
+    INSERT INTO {tablename} (id, value, simple_text, utf8_text,
+      day, date_time)
+    VALUES
+      (%1, %2, %3, %4, %5, %6)
       """).strip()
 
 

--- a/test/unit/test_db_helpers.py
+++ b/test/unit/test_db_helpers.py
@@ -10,7 +10,7 @@ import psycopg2
 from etlhelper import DbParams
 from etlhelper.db_helper_factory import DB_HELPER_FACTORY
 from etlhelper.db_helpers import (
-    OracleDbHelper,
+    OracleDbHelper, MSSQLDbHelper, PostgresDbHelper, SQLiteDbHelper
 )
 
 # pylint: disable=missing-docstring
@@ -35,6 +35,16 @@ def test_oracle_sql_exceptions():
 def test_oracle_connect_exceptions():
     helper = OracleDbHelper()
     assert helper.connect_exceptions == (cx_Oracle.DatabaseError)
+
+
+@pytest.mark.parametrize('helper, expected', [
+    (OracleDbHelper, 'named'),
+    (MSSQLDbHelper, 'qmark'),
+    (PostgresDbHelper, 'pyformat'),
+    (SQLiteDbHelper, 'qmark')
+])
+def test_paramstyle(helper, expected):
+    assert helper().paramstyle == expected
 
 
 @pytest.mark.parametrize('db_params, driver, expected', [

--- a/test/unit/test_db_helpers.py
+++ b/test/unit/test_db_helpers.py
@@ -27,14 +27,25 @@ POSTGRESDB = DbParams(dbtype='PG', host='server', port='1521', dbname='testdb',
 SQLITEDB = DbParams(dbtype='SQLITE', filename='/myfile.db')
 
 
-def test_oracle_sql_exceptions():
-    helper = OracleDbHelper()
-    assert helper.sql_exceptions == (cx_Oracle.DatabaseError)
+@pytest.mark.parametrize('helper, expected', [
+    (OracleDbHelper, (cx_Oracle.DatabaseError)),
+    (MSSQLDbHelper, (pyodbc.DatabaseError)),
+    (PostgresDbHelper, (psycopg2.ProgrammingError, psycopg2.InterfaceError,
+                        psycopg2.InternalError)),
+    (SQLiteDbHelper, (sqlite3.OperationalError, sqlite3.IntegrityError))
+])
+def test_sql_exceptions(helper, expected):
+    assert helper().sql_exceptions == expected
 
 
-def test_oracle_connect_exceptions():
-    helper = OracleDbHelper()
-    assert helper.connect_exceptions == (cx_Oracle.DatabaseError)
+@pytest.mark.parametrize('helper, expected', [
+    (OracleDbHelper, (cx_Oracle.DatabaseError)),
+    (MSSQLDbHelper, (pyodbc.DatabaseError, pyodbc.InterfaceError)),
+    (PostgresDbHelper, (psycopg2.OperationalError)),
+    (SQLiteDbHelper, (sqlite3.OperationalError))
+])
+def test_connect_exceptions(helper, expected):
+    assert helper().connect_exceptions == expected
 
 
 @pytest.mark.parametrize('helper, expected', [


### PR DESCRIPTION
### Description

The DBAPI 2.0 specification allows different placeholder formats to be used for parameters in queries e.g. `?`, `:name`, `%s`.  It can be confusing when moving between different database drivers, as they use different ones.  The `paramstyle` attribute of the driver defines which kind should be used.

This merge request adds the `paramstyle` to the DbHelper objects so that is can be checked.  It also updates the error messages in the ETL functions so they display the expected paramstyle.  This will make debugging easier.

Closes #3

### To test

+ [ ] Confirm tests pass
+ [ ] Write a bad query and confirm paramstyle is displayed in message