### PR TITLE
Catch StopIteration raised when fetchone() is empty

### DIFF
--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -149,8 +149,13 @@ def fetchone(select_query, conn, parameters=(),
     :param transform: function that accepts an iterable (e.g. list) of rows and
                       returns an iterable of rows (possibly of different shape)
     """
-    return next(iter_rows(select_query, conn, row_factory=row_factory,
-                          parameters=parameters, transform=transform))
+    try:
+        result = next(iter_rows(select_query, conn, row_factory=row_factory,
+                                parameters=parameters, transform=transform))
+    except StopIteration:
+        result = None
+
+    return result
 
 
 def fetchmany(select_query, conn, size=1, parameters=(),

--- a/test/integration/etl/test_etl_extract.py
+++ b/test/integration/etl/test_etl_extract.py
@@ -133,6 +133,13 @@ def test_fetchone_happy_path(pgtestdb_test_tables, pgtestdb_conn,
     assert result == test_table_data[0]
 
 
+def test_fetchone_none(pgtestdb_test_tables, pgtestdb_conn,
+                       test_table_data):
+    sql = "SELECT * FROM src WHERE id=999"
+    result = fetchone(sql, pgtestdb_conn)
+    assert result is None
+
+
 @pytest.mark.parametrize('size', [1, 3, 1000])
 def test_fetchmany_happy_path(pgtestdb_test_tables, pgtestdb_conn,
                               test_table_data, size):


### PR DESCRIPTION
This fix had already been submitted by @metazool and merged by @dvalters, but somehow it isn't in the `main` branch now.  This pull request adds it again.

https://github.com/BritishGeologicalSurvey/etlhelper/pull/42