### PR TITLE
Add connect module functions to DbParams

### DIFF
--- a/etlhelper/__init__.py
+++ b/etlhelper/__init__.py
@@ -18,11 +18,13 @@ from etlhelper.etl import (
     iter_chunks,
     iter_rows,
 )
+"""
 from etlhelper.connect import (
     connect,
     get_connection_string,
     get_sqlalchemy_connection_string,
 )
+"""
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/etlhelper/__init__.py
+++ b/etlhelper/__init__.py
@@ -18,13 +18,11 @@ from etlhelper.etl import (
     iter_chunks,
     iter_rows,
 )
-"""
 from etlhelper.connect import (
     connect,
     get_connection_string,
     get_sqlalchemy_connection_string,
 )
-"""
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/etlhelper/db_params.py
+++ b/etlhelper/db_params.py
@@ -5,13 +5,15 @@ parameters.
 import os
 import socket
 
+from etlhelper.connect import connect, get_connection_string, get_sqlalchemy_connection_string
 from etlhelper.db_helper_factory import DB_HELPER_FACTORY
 from etlhelper.exceptions import ETLHelperDbParamsError, ETLHelperHelperError
 
 
 class DbParams(dict):
-    """Generic data holder class for database connection parameters.
+    """Generic data holder class for database connection parameters."""
 
+    """
     As we do not know which parameters will be provided in advance, DbParams
     subclasses dict, to give dynamic attributes, following the pattern described
     here: https://amir.rachum.com/blog/2016/10/05/python-dynamic-attributes/
@@ -107,6 +109,34 @@ class DbParams(dict):
         finally:
             s.close()
 
+    def connect(self, password_variable, **kwargs):
+        """
+        Return database connection.
+
+        :param password_variable: str, name of environment variable with password
+        :param kwargs: connection specific keyword arguments e.g. row_factory
+        :return: Connection object
+        """
+        return connect(self, password_variable, **kwargs)
+
+    def get_connection_string(self, password_variable):
+        """
+        Return the connection string.
+
+        :param password_variable: str, name of environment variable with password
+        :return: str, Connection string
+        """
+        return get_connection_string(self, password_variable)
+
+    def get_sqlalchemy_connection_string(self, password_variable):
+        """
+        Get a SQLAlchemy connection string.
+
+        :param password_variable: str, name of environment variable with password
+        :return: str, Connection string
+        """
+        return get_sqlalchemy_connection_string(self, password_variable)
+
     def copy(self):
         """
         Return a shallow copy of DbParams object.
@@ -114,6 +144,11 @@ class DbParams(dict):
         :return DbParams: DbParams object with same attributes as original.
         """
         return self.__class__(**self)
+
+    @property
+    def paramstyle(self):
+        """The DBAPI2 paramstyle attribute for database type"""
+        return DB_HELPER_FACTORY.from_dbtype(self.dbtype).paramstyle
 
     def __repr__(self):
         key_val_str = ", ".join([f"{key}='{self[key]}'" for key in self.keys()])

--- a/test/unit/test_db_params.py
+++ b/test/unit/test_db_params.py
@@ -6,7 +6,7 @@ import pytest
 
 from etlhelper.db_params import DbParams
 from etlhelper.exceptions import ETLHelperDbParamsError
-import etlhelper.connect as etl_connect
+import etlhelper.db_params as etl_db_params
 
 
 @pytest.fixture(scope='function')
@@ -105,7 +105,7 @@ def test_db_params_connect(test_params, monkeypatch):
     """
     # Arrange
     mock_connect = Mock()
-    monkeypatch.setattr(etl_connect, "connect", mock_connect)
+    monkeypatch.setattr(etl_db_params, "connect", mock_connect)
 
     # Act
     test_params.connect("PASSWORD_VARIABLE", foobarkey="blah")

--- a/test/unit/test_db_params.py
+++ b/test/unit/test_db_params.py
@@ -1,10 +1,12 @@
 """
 Test db params
 """
+from unittest.mock import Mock
 import pytest
 
 from etlhelper.db_params import DbParams
 from etlhelper.exceptions import ETLHelperDbParamsError
+import etlhelper.connect as etl_connect
 
 
 @pytest.fixture(scope='function')
@@ -94,3 +96,54 @@ def test_db_params_copy(test_params):
     assert test_params2 == test_params
     assert test_params2 is not test_params
     assert isinstance(test_params2, DbParams)
+
+
+def test_db_params_connect(test_params, monkeypatch):
+    """
+    Assert that the connect function is called with the params object
+    and the password variable.
+    """
+    # Arrange
+    mock_connect = Mock()
+    monkeypatch.setattr(etl_connect, "connect", mock_connect)
+
+    # Act
+    test_params.connect("PASSWORD_VARIABLE", foobarkey="blah")
+
+    # Assert
+    mock_connect.assert_called_once_with(test_params, "PASSWORD_VARIABLE", foobarkey="blah")
+
+
+def test_db_params_get_connection_string(test_params, monkeypatch):
+    """
+    Test that the correct connection string is given when using the
+    DbParams method for connect.
+    """
+    # Arrange
+    monkeypatch.setenv("PASSWORD_VARIABLE", "blahblahblah")
+
+    # Act
+    conn_str = test_params.get_connection_string("PASSWORD_VARIABLE")
+
+    # Assert
+    assert conn_str == 'host=localhost port=5432 dbname=etlhelper user=etlhelper_user password=blahblahblah'  # noqa
+
+
+def test_db_params_get_sqlalchemy_connection_string(test_params, monkeypatch):
+    """
+    Test that the correct connection string is given when using the
+    DbParams method for connect, for a SQL Alchemy.
+    """
+    # Arrange
+    monkeypatch.setenv("PASSWORD_VARIABLE", "blahblahblah")
+
+    # Act
+    conn_str = test_params.get_sqlalchemy_connection_string("PASSWORD_VARIABLE")
+
+    # Assert
+    assert conn_str == 'postgresql://etlhelper_user:blahblahblah@localhost:5432/etlhelper'
+
+
+def test_db_params_paramstyle(test_params):
+    """Test that the correct paramstyle string is returned."""
+    assert test_params.paramstyle == 'pyformat'


### PR DESCRIPTION
This merge request adds `connect`, `get_connection_string` and methods `get_sqlalchemy_string`, plus a `paramstyle` property to the DbParams class.

Closes #65 
Closes #66 