### PR TITLE
Typos comments and dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitlab
+bin
+docs
+*.egg-info
+venv
+coverage
+.coverage

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,13 @@ docs
 venv
 coverage
 .coverage
+.gitlab-ci.yml
+.mypy_cache
+.pytest_cache
+**/__pycache__
+htmlcov
+.travis.yml
+
+# Instant Client files are installed to following directory
+# during local development
+etlhelper/oracle_instantclient/*

--- a/etlhelper/db_helpers/db_helper.py
+++ b/etlhelper/db_helpers/db_helper.py
@@ -24,7 +24,7 @@ class DbHelper(metaclass=ABCMeta):
         self.paramstyle = ''
         # Dummy function to allowing calling in connect below
         # (To satisfy Pylint)
-        # Throws exception if not overidden
+        # Throws exception if not overridden
         self._connect_func = lambda conn_str: 1/0
 
     def connect(self, db_params, password_variable=None, **kwargs):

--- a/etlhelper/db_helpers/mssql.py
+++ b/etlhelper/db_helpers/mssql.py
@@ -25,7 +25,7 @@ class MSSQLDbHelper(DbHelper):
         """
         Return a connection string
         :param db_params: DbParams
-        :param password: str, password
+        :param password_variable: str, password
         :return: str
         """
         # Prepare connection string

--- a/etlhelper/db_helpers/oracle.py
+++ b/etlhelper/db_helpers/oracle.py
@@ -24,7 +24,7 @@ class OracleDbHelper(DbHelper):
         """
         Return a connection string
         :param db_params: DbParams
-        :param password: str, password
+        :param password_variable: str, password
         :return: str
         """
         # Prepare connection string

--- a/etlhelper/db_helpers/postgres.py
+++ b/etlhelper/db_helpers/postgres.py
@@ -27,7 +27,7 @@ class PostgresDbHelper(DbHelper):
         """
         Return a connection string
         :param db_params: DbParams
-        :param password: str, password
+        :param password_variable: str, password
         :return: str
         """
         # Prepare connection string

--- a/etlhelper/setup_oracle_client.py
+++ b/etlhelper/setup_oracle_client.py
@@ -207,7 +207,7 @@ def _symlink_libraries(install_dir):
     clntsh_link = install_dir / 'libclntsh.so'
 
     # Some versions of InstantClient will have a placeholder file
-    # for where the symlink should be, rahter than a symlink.
+    # for where the symlink should be, rather than a symlink.
     # It must be removed before trying to create a real symlink.
 
     # unlink(missing_ok=True) would be possible in Python 3.8+

--- a/test/integration/db/test_sqlite.py
+++ b/test/integration/db/test_sqlite.py
@@ -33,7 +33,7 @@ def test_connect(sqlitedb):
 
 @pytest.mark.skipif(sys.platform != 'linux', reason='Requires Linux OS')
 def test_bad_connect(tmpdir):
-    # Attemping to create file in non-existent directory should fail
+    # Attempting to create file in non-existent directory should fail
     try:
         db_params = DbParams(dbtype='SQLITE', filename='/does/not/exist')
         with pytest.raises(ETLHelperConnectionError):


### PR DESCRIPTION
Hi!

Learned about `etlhelper` via Twitter today. Unfortunately didn't have much time to experiment with it today. At my previous role in my current job, I had to manage some ETL jobs (Perl + Make, Talend, and orchestrated by Jenkins or triggered manually).

I will drop a message later to a co-worker who is responsible for those jobs now, to let her know about `etlhelper`. It sounds like a very good tool for the kind of jobs we have, though not sure if she'd have the time (and courage, some of that Perl code hasn't been touched in years) to upgrade it.

Had a look at the code, and it looks really great! Very simple and well documented. :+1: :clap: 

This PR just fixes some docstring params, a couple typos, and also added a [dockerignore](https://docs.docker.com/engine/reference/builder/#dockerignore-file).

Building the image (which I thought was for testing the tool, but looks more intended for developers?) without the ignore file:

```bash
kinow@ranma:~/Development/python/workspace/etlhelper$ docker build -t etlhelper-test-runner .
Sending build context to Docker daemon  74.99MB
...
```

Then with the ignore

```bash
kinow@ranma:~/Development/python/workspace/etlhelper$ docker build -t etlhelper-test-runner .
Sending build context to Docker daemon  461.8kB
```

Won't really bring much performance improvement (though some, probably) but at least the building context of the container will be simpler, and I think it's also considered more secure. Anyhoo, thanks a lot for sharing it with others.

Cheers
Bruno