### PR TITLE
Warn on no driver

### DIFF
--- a/etlhelper/db_helpers/db_helper.py
+++ b/etlhelper/db_helpers/db_helper.py
@@ -2,10 +2,13 @@
 Database helper classes using Factory Pattern
 """
 from abc import ABCMeta, abstractmethod
+import logging
 import sys
 import os
 
 from etlhelper.exceptions import ETLHelperConnectionError
+
+logger = logging.getLogger('etlhelper')
 
 
 class DbHelper(metaclass=ABCMeta):
@@ -63,12 +66,12 @@ class DbHelper(metaclass=ABCMeta):
         :raises ETLHelperDbParamsError: Exception when parameter not defined
         """
         if not password_variable:
-            print("Name of password environment variable e.g. ORACLE_PASSWORD is required")
+            logger.error("Name of password environment variable e.g. ORACLE_PASSWORD is required")
             sys.exit(1)
         try:
             return os.environ[password_variable]
         except KeyError:
-            print(f"Password environment variable ({password_variable}) is not set")
+            logger.error(f"Password environment variable ({password_variable}) is not set")
             sys.exit(1)
 
     @staticmethod

--- a/etlhelper/db_helpers/db_helper.py
+++ b/etlhelper/db_helpers/db_helper.py
@@ -25,10 +25,10 @@ class DbHelper(metaclass=ABCMeta):
         self.connect_exceptions = tuple()
         self.required_params = set()
         self.paramstyle = ''
-        # Dummy function to allowing calling in connect below
-        # (To satisfy Pylint)
-        # Throws exception if not overridden
-        self._connect_func = lambda conn_str: 1/0
+        self.missing_driver_msg = ''
+        # This is overridden with real connect method when DbHelper class is
+        # successfully initialised if driver is installed
+        self._connect_func = self._raise_missing_driver_error_on_connect
 
     def connect(self, db_params, password_variable=None, **kwargs):
         """
@@ -101,3 +101,11 @@ class DbHelper(metaclass=ABCMeta):
         :param conn: Open database connection.
         """
         return conn.cursor()
+
+    def _raise_missing_driver_error_on_connect(self, *args, **kwargs):
+        """
+        Raise an exception with helpful message if user tries to connect without driver installed.
+        This function replaces a connect function, so *args and **kwargs are collected to allow
+        it to accept whatever would be passed to that function.
+        """
+        raise ETLHelperConnectionError(self.missing_driver_msg)

--- a/etlhelper/db_helpers/db_helper.py
+++ b/etlhelper/db_helpers/db_helper.py
@@ -3,7 +3,6 @@ Database helper classes using Factory Pattern
 """
 from abc import ABCMeta, abstractmethod
 import logging
-import sys
 import os
 
 from etlhelper.exceptions import ETLHelperConnectionError
@@ -48,13 +47,10 @@ class DbHelper(metaclass=ABCMeta):
 
         # Create connection
         try:
-            # This method is not defined? (Only an attribute)
             conn = self._connect_func(conn_str, **kwargs)
         except self.connect_exceptions as exc:
             msg = f"Error connecting to {conn_str} via dbapi: {exc}"
             raise ETLHelperConnectionError(msg)
-            # sys.exit(1)
-
         return conn
 
     @staticmethod
@@ -66,13 +62,15 @@ class DbHelper(metaclass=ABCMeta):
         :raises ETLHelperDbParamsError: Exception when parameter not defined
         """
         if not password_variable:
-            logger.error("Name of password environment variable e.g. ORACLE_PASSWORD is required")
-            sys.exit(1)
+            msg = "Name of password environment variable e.g. ORACLE_PASSWORD is required"
+            logger.error(msg)
+            raise ETLHelperConnectionError(msg)
         try:
             return os.environ[password_variable]
         except KeyError:
-            logger.error(f"Password environment variable ({password_variable}) is not set")
-            sys.exit(1)
+            msg = f"Password environment variable ({password_variable}) is not set"
+            logger.error(msg)
+            raise ETLHelperConnectionError(msg)
 
     @staticmethod
     @abstractmethod

--- a/etlhelper/db_helpers/mssql.py
+++ b/etlhelper/db_helpers/mssql.py
@@ -1,6 +1,7 @@
 """
 Database helper for mssql
 """
+import warnings
 from etlhelper.db_helpers.db_helper import DbHelper
 
 
@@ -10,16 +11,17 @@ class MSSQLDbHelper(DbHelper):
     """
     def __init__(self):
         super().__init__()
+        self.required_params = {'host', 'port', 'dbname', 'user', 'odbc_driver'}
         try:
             import pyodbc
             self.sql_exceptions = (pyodbc.DatabaseError)
             self.connect_exceptions = (pyodbc.DatabaseError, pyodbc.InterfaceError)
             self.paramstyle = pyodbc.paramstyle
             self._connect_func = pyodbc.connect
-            self.required_params = {'host', 'port', 'dbname', 'user', 'odbc_driver'}
         except ImportError:
-            print("The pyodc Python package could not be found.\n"
-                  "Run: python -m pip install pyodbc")
+            msg = ("Could not import pyodbc module required for MS SQL connections.  "
+                   "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
+            warnings.warn(msg)
 
     def get_connection_string(self, db_params, password_variable):
         """
@@ -35,7 +37,7 @@ class MSSQLDbHelper(DbHelper):
 
     def get_sqlalchemy_connection_string(self, db_params, password_variable):
         """
-        Returns connection string for sql alchemy type
+        Returns connection string for SQLAlchemy engine.
         """
         password = self.get_password(password_variable)
         driver = db_params.odbc_driver.replace(" ", "+")

--- a/etlhelper/db_helpers/mssql.py
+++ b/etlhelper/db_helpers/mssql.py
@@ -12,6 +12,9 @@ class MSSQLDbHelper(DbHelper):
     def __init__(self):
         super().__init__()
         self.required_params = {'host', 'port', 'dbname', 'user', 'odbc_driver'}
+        self.missing_driver_msg = (
+            "Could not import pyodbc module required for MS SQL connections.  "
+            "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
         try:
             import pyodbc
             self.sql_exceptions = (pyodbc.DatabaseError)
@@ -19,9 +22,7 @@ class MSSQLDbHelper(DbHelper):
             self.paramstyle = pyodbc.paramstyle
             self._connect_func = pyodbc.connect
         except ImportError:
-            msg = ("Could not import pyodbc module required for MS SQL connections.  "
-                   "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
-            warnings.warn(msg)
+            warnings.warn(self.missing_driver_msg)
 
     def get_connection_string(self, db_params, password_variable):
         """

--- a/etlhelper/db_helpers/oracle.py
+++ b/etlhelper/db_helpers/oracle.py
@@ -1,6 +1,7 @@
 """
 Database helper for Oracle
 """
+import warnings
 from etlhelper.db_helpers.db_helper import DbHelper
 
 
@@ -10,15 +11,17 @@ class OracleDbHelper(DbHelper):
     """
     def __init__(self):
         super().__init__()
+        self.required_params = {'host', 'port', 'dbname', 'user'}
         try:
             import cx_Oracle
             self.sql_exceptions = (cx_Oracle.DatabaseError)
             self.connect_exceptions = (cx_Oracle.DatabaseError)
             self.paramstyle = cx_Oracle.paramstyle
             self._connect_func = cx_Oracle.connect
-            self.required_params = {'host', 'port', 'dbname', 'user'}
         except ImportError:
-            print("The cxOracle drivers were not found. See setup guide for more information.")
+            msg = ("Could not import cx_Oracle module required for Oracle connections.  "
+                   "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
+            warnings.warn(msg)
 
     def get_connection_string(self, db_params, password_variable):
         """
@@ -34,9 +37,8 @@ class OracleDbHelper(DbHelper):
 
     def get_sqlalchemy_connection_string(self, db_params, password_variable):
         """
-        Returns connection string for sql alchemy type connections
+        Returns connection string for SQLAlchemy engine.
         """
         password = self.get_password(password_variable)
-
         return (f'oracle://{db_params.user}:{password}@'
                 f'{db_params.host}:{db_params.port}/{db_params.dbname}')

--- a/etlhelper/db_helpers/oracle.py
+++ b/etlhelper/db_helpers/oracle.py
@@ -12,6 +12,9 @@ class OracleDbHelper(DbHelper):
     def __init__(self):
         super().__init__()
         self.required_params = {'host', 'port', 'dbname', 'user'}
+        self.missing_driver_msg = (
+            "Could not import cx_Oracle module required for Oracle connections.  "
+            "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
         try:
             import cx_Oracle
             self.sql_exceptions = (cx_Oracle.DatabaseError)
@@ -19,9 +22,7 @@ class OracleDbHelper(DbHelper):
             self.paramstyle = cx_Oracle.paramstyle
             self._connect_func = cx_Oracle.connect
         except ImportError:
-            msg = ("Could not import cx_Oracle module required for Oracle connections.  "
-                   "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
-            warnings.warn(msg)
+            warnings.warn(self.missing_driver_msg)
 
     def get_connection_string(self, db_params, password_variable):
         """

--- a/etlhelper/db_helpers/postgres.py
+++ b/etlhelper/db_helpers/postgres.py
@@ -1,6 +1,7 @@
 """
-Database helper for Postgres
+Database helper for PostgreSQL
 """
+import warnings
 from etlhelper.db_helpers.db_helper import DbHelper
 
 
@@ -10,6 +11,7 @@ class PostgresDbHelper(DbHelper):
     """
     def __init__(self):
         super().__init__()
+        self.required_params = {'host', 'port', 'dbname', 'user'}
         try:
             import psycopg2
             self.sql_exceptions = (psycopg2.ProgrammingError,
@@ -18,10 +20,10 @@ class PostgresDbHelper(DbHelper):
             self.connect_exceptions = (psycopg2.OperationalError)
             self.paramstyle = psycopg2.paramstyle
             self._connect_func = psycopg2.connect
-            self.required_params = {'host', 'port', 'dbname', 'user'}
         except ImportError:
-            print("The PostgreSQL python libraries could not be found.\n"
-                  "Run: python -m pip install psycopg2-binary")
+            msg = ("Could not import psycopg2 module required for PostgreSQL connections.  "
+                   "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
+            warnings.warn(msg)
 
     def get_connection_string(self, db_params, password_variable):
         """
@@ -38,7 +40,7 @@ class PostgresDbHelper(DbHelper):
 
     def get_sqlalchemy_connection_string(self, db_params, password_variable):
         """
-        Returns connection string for sql alchemy
+        Returns connection string for SQLAlchemy engine.
         """
         password = self.get_password(password_variable)
         return (f'postgresql://{db_params.user}:{password}@'

--- a/etlhelper/db_helpers/postgres.py
+++ b/etlhelper/db_helpers/postgres.py
@@ -12,6 +12,9 @@ class PostgresDbHelper(DbHelper):
     def __init__(self):
         super().__init__()
         self.required_params = {'host', 'port', 'dbname', 'user'}
+        self.missing_driver_msg = (
+            "Could not import psycopg2 module required for PostgreSQL connections.  "
+            "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
         try:
             import psycopg2
             self.sql_exceptions = (psycopg2.ProgrammingError,
@@ -21,9 +24,7 @@ class PostgresDbHelper(DbHelper):
             self.paramstyle = psycopg2.paramstyle
             self._connect_func = psycopg2.connect
         except ImportError:
-            msg = ("Could not import psycopg2 module required for PostgreSQL connections.  "
-                   "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
-            warnings.warn(msg)
+            warnings.warn(self.missing_driver_msg)
 
     def get_connection_string(self, db_params, password_variable):
         """

--- a/etlhelper/db_helpers/sqlite.py
+++ b/etlhelper/db_helpers/sqlite.py
@@ -2,6 +2,7 @@
 Database helper for SQLite
 """
 from contextlib import contextmanager
+import warnings
 from etlhelper.db_helpers.db_helper import DbHelper
 
 
@@ -11,6 +12,7 @@ class SQLiteDbHelper(DbHelper):
     """
     def __init__(self):
         super().__init__()
+        self.required_params = {'filename'}
         try:
             import sqlite3
             self.sql_exceptions = (sqlite3.OperationalError,
@@ -18,10 +20,10 @@ class SQLiteDbHelper(DbHelper):
             self.connect_exceptions = (sqlite3.OperationalError)
             self.paramstyle = sqlite3.paramstyle
             self._connect_func = sqlite3.connect
-            self.required_params = {'filename'}
         except ImportError:
-            print("The sqlite3 module was not found. Check configuration as "
-                  "it should be in Python's standard library.")
+            msg = ("Could not import sqlite3 module required for SQLite connections.  "
+                   "Check Python configuration - this should be part of Standard Library.")
+            warnings.warn(msg)
 
     def get_connection_string(self, db_params, password_variable=None):
         """

--- a/etlhelper/db_helpers/sqlite.py
+++ b/etlhelper/db_helpers/sqlite.py
@@ -13,6 +13,9 @@ class SQLiteDbHelper(DbHelper):
     def __init__(self):
         super().__init__()
         self.required_params = {'filename'}
+        self.missing_driver_msg = (
+            "Could not import sqlite3 module required for SQLite connections.  "
+            "Check Python configuration - this should be part of Standard Library.")
         try:
             import sqlite3
             self.sql_exceptions = (sqlite3.OperationalError,
@@ -21,9 +24,7 @@ class SQLiteDbHelper(DbHelper):
             self.paramstyle = sqlite3.paramstyle
             self._connect_func = sqlite3.connect
         except ImportError:
-            msg = ("Could not import sqlite3 module required for SQLite connections.  "
-                   "Check Python configuration - this should be part of Standard Library.")
-            warnings.warn(msg)
+            warnings.warn(self.missing_driver_msg)
 
     def get_connection_string(self, db_params, password_variable=None):
         """

--- a/etlhelper/db_params.py
+++ b/etlhelper/db_params.py
@@ -86,9 +86,15 @@ class DbParams(dict):
 
         # Ensure dbtype has been set
         dbtype_var = f'{prefix}dbtype'
-        if 'dbtype' not in dbparams_from_env:
+        dbtype = dbparams_from_env.get('dbtype', None)
+        if dbtype is None:
             msg = f"{dbtype_var} environment variable is not set"
             raise ETLHelperDbParamsError(msg)
+
+        # Only include the required params
+        # This prevents something like ETLHelper_password being added
+        required_params = DB_HELPER_FACTORY.from_dbtype(dbtype).required_params | {'dbtype'}
+        dbparams_from_env = {key: dbparams_from_env[key] for key in required_params}
 
         return cls(**dbparams_from_env)
 

--- a/etlhelper/db_params.py
+++ b/etlhelper/db_params.py
@@ -2,8 +2,10 @@
 This module defines the DbParams class for storing database connection
 parameters.
 """
+from contextlib import contextmanager
 import os
 import socket
+import sys
 
 from etlhelper.connect import connect, get_connection_string, get_sqlalchemy_connection_string
 from etlhelper.db_helper_factory import DB_HELPER_FACTORY
@@ -60,7 +62,8 @@ class DbParams(dict):
             required_params = DB_HELPER_FACTORY.from_dbtype(self.dbtype).required_params
         except ETLHelperHelperError:
             msg = f'{self.dbtype} not in valid types ({DB_HELPER_FACTORY.helpers.keys()})'
-            raise ETLHelperDbParamsError(msg)
+            with simplify_stack_trace():
+                raise ETLHelperDbParamsError(msg)
 
         unset_params = (given ^ required_params) & required_params
         if unset_params:
@@ -167,3 +170,19 @@ class DbParams(dict):
 
     def __str__(self):
         return self.__repr__()
+
+
+@contextmanager
+def simplify_stack_trace():
+    """
+    Limit the stack trace so that it only includes the exception type and
+    value, without the code listings.  By default, Python will print the whole
+    trace, which can be confusing for some exceptions where the problem occurs
+    far from where the code written by the developer.
+    """
+    # See https://stackoverflow.com/questions/38598740/raising-errors-without-traceback
+    old_tracebacklimit = sys.__dict__.get('tracebacklimit', 1000)
+
+    sys.tracebacklimit = 0
+    yield
+    sys.tracebacklimit = old_tracebacklimit

--- a/etlhelper/setup_oracle_client.py
+++ b/etlhelper/setup_oracle_client.py
@@ -38,14 +38,14 @@ def setup_oracle_client(zip_location, reinstall=False):
 
     # Return if configured already
     if _oracle_client_is_configured() and not reinstall:
-        logging.info('Oracle Client library is correctly configured')
+        logging.info('Oracle Client library is correctly configured.')
         print(ld_library_prepend_script.absolute())
         return
 
     # Quit with help message if not Linux
     if sys.platform != 'linux':
         # Message for Windows and Mac users
-        print(WINDOWS_INSTALL_MESSAGE)
+        logging.error(WINDOWS_INSTALL_MESSAGE)
         sys.exit(1)
 
     # Gather facts
@@ -136,7 +136,7 @@ def _create_install_dir(install_dir):
     try:
         install_dir.mkdir()
     except PermissionError:
-        print(dedent(f"""
+        logging.error(dedent(f"""
             Permission denied to required Python directory: {install_dir}
             Consider using a virtual environment.""".strip()))
         sys.exit(1)

--- a/test/integration/db/test_sqlite.py
+++ b/test/integration/db/test_sqlite.py
@@ -17,13 +17,8 @@ from etlhelper.exceptions import (
     ETLHelperQueryError
 )
 
-# Skip these tests if database is unreachable
-ORADB = DbParams.from_environment(prefix='TEST_ORACLE_')
-if not ORADB.is_reachable():
-    pytest.skip('Oracle test database is unreachable', allow_module_level=True)
-
-
 # -- Tests here --
+
 
 def test_connect(sqlitedb):
     conn = connect(sqlitedb)

--- a/test/integration/test_dbparams.py
+++ b/test/integration/test_dbparams.py
@@ -21,9 +21,7 @@ def test_is_unreachable(pgtestdb_params):
 def test_sqlite_dbparam_not_supported():
     sqlitedb = DbParams(
         dbtype='SQLITE',
-        filename='sqlite.db',
-        dbname='etlhelper',
-        user='etlhelper_user')
+        filename='sqlite.db')
 
     with pytest.raises(ValueError):
         sqlitedb.is_reachable()

--- a/test/unit/test_db_helpers.py
+++ b/test/unit/test_db_helpers.py
@@ -22,7 +22,7 @@ MSSQLDB = DbParams(dbtype='MSSQL', host='server', port='1521', dbname='testdb',
                    user='testuser', odbc_driver='test driver')
 
 POSTGRESDB = DbParams(dbtype='PG', host='server', port='1521', dbname='testdb',
-                      user='testuser', odbc_driver='test driver')
+                      user='testuser')
 
 SQLITEDB = DbParams(dbtype='SQLITE', filename='/myfile.db')
 

--- a/test/unit/test_db_helpers.py
+++ b/test/unit/test_db_helpers.py
@@ -128,3 +128,17 @@ def test_connect_without_driver_raises_exception(db_params, driver, monkeypatch)
     error_message = excinfo.value.args[0]
     assert "Could not import" in error_message
     assert driver in error_message
+
+
+@pytest.mark.parametrize('db_params', [ORACLEDB, MSSQLDB, POSTGRESDB])
+def test_connect_without_password_variable_raises_exception(db_params):
+    with pytest.raises(ETLHelperConnectionError,
+                       match=r"Name of password environment variable .* is required"):
+        db_params.connect(None)
+
+
+@pytest.mark.parametrize('db_params', [ORACLEDB, MSSQLDB, POSTGRESDB])
+def test_connect_with_unset_password_variable_raises_exception(db_params):
+    with pytest.raises(ETLHelperConnectionError,
+                       match=r"Password environment variable .* is not set"):
+        db_params.connect("This environment variable is not set")

--- a/test/unit/test_db_params.py
+++ b/test/unit/test_db_params.py
@@ -76,6 +76,7 @@ def test_db_params_from_environment(monkeypatch):
     monkeypatch.setenv('TEST_DB_PARAMS_ENV_PORT', '1234')
     monkeypatch.setenv('TEST_DB_PARAMS_ENV_DBNAME', 'testdb')
     monkeypatch.setenv('TEST_DB_PARAMS_ENV_USER', 'testuser')
+    monkeypatch.setenv('TEST_DB_PARAMS_ENV_PASSWORD', 'dont want this')
 
     # Act
     db_params = DbParams.from_environment(prefix='TEST_DB_PARAMS_ENV_')
@@ -86,6 +87,10 @@ def test_db_params_from_environment(monkeypatch):
     assert db_params.port == '1234'
     assert db_params.dbname == 'testdb'
     assert db_params.user == 'testuser'
+
+    # Confirm that password variable wasn't included
+    assert 'PASSWORD' not in db_params
+    assert 'password' not in db_params
 
 
 def test_db_params_from_environment_not_set(monkeypatch):

--- a/test/unit/test_db_params.py
+++ b/test/unit/test_db_params.py
@@ -21,9 +21,23 @@ def test_params():
     return test_params_example
 
 
-def test_db_params_validate_params():
+def test_db_params_validate_params_invalid_dbtype():
     with pytest.raises(ETLHelperDbParamsError, match=r'.* not in valid types .*'):
         DbParams(dbtype='not valid')
+
+
+def test_db_params_validate_params_missing_params():
+    with pytest.raises(ETLHelperDbParamsError,
+                       match=r"{'user'} not set. Required parameters are .*"):
+        # missing user
+        DbParams(dbtype='ORACLE', host='localhost', port=1, dbname='test')
+
+
+def test_db_params_validate_params_extra_param():
+    with pytest.raises(ETLHelperDbParamsError,
+                       match=r"Invalid parameter\(s\): {'extra_param'}"):
+        DbParams(dbtype='ORACLE', host='localhost', port=1, dbname='test',
+                 user='user', extra_param=1)
 
 
 def test_db_params_repr(test_params):
@@ -45,9 +59,11 @@ def test_db_params_setattr(test_params):
 
 def test_db_params_setattr_bad_param(test_params):
     """Test that __setattr__ approach fails for bad parameter"""
-    with pytest.raises(AttributeError, match=r'.* is not a valid DbParams attribute: .*'):
-        # Set a param using dot notation
+    with pytest.raises(ETLHelperDbParamsError, match=r"Invalid parameter\(s\): {'some_bad_param'}"):
+        # Set a param using dot notation and confirm error
         test_params.some_bad_param = "Data McDatabase"
+    # Confirm param is not set
+    assert test_params.get('some_bad_param', 'not_found') == 'not_found'
 
 
 def test_db_params_from_environment(monkeypatch):

--- a/test/unit/test_db_params.py
+++ b/test/unit/test_db_params.py
@@ -22,8 +22,12 @@ def test_params():
 
 
 def test_db_params_validate_params_invalid_dbtype():
-    with pytest.raises(ETLHelperDbParamsError, match=r'.* not in valid types .*'):
+    with pytest.raises(ETLHelperDbParamsError, match=r'.* not in valid types .*') as excinfo:
         DbParams(dbtype='not valid')
+
+    # Check that exception doesn't include lower exceptions from stack
+    exception_chain = excinfo.getrepr().chain
+    assert len(exception_chain) == 1
 
 
 def test_db_params_validate_params_missing_params():


### PR DESCRIPTION
### Summary

This merge request changes the console output of `etllhelper` so that:

+ Messages raised when creating a `DbParams` object for which no driver is installed are raised as `UserWarning` instead of print.
+ These messages are standardised across different db_helper classes.
+ Messages printed prior to a `sys.exit()` are raised via `logging.error`

This should result in clean `stdout`, with the `print()` only ever used to return the file path of the ld_library_update script.  All other messages go to `stderr`.  If required, the UserWarning can be turned off e.g. via environment variable `PYTHONWARNINGS=ignore.

Closes #27.

https://stackoverflow.com/questions/14463277/how-to-disable-python-warnings

During this work, it was noticed that it was possible to create DbParams objects with invalid sets of parameters, as the required_parameters were never loaded if the driver package import failed.  Two additional commits in this pull request fix this bug and now ensure that the parameter list is always correct.

### To test

+ [x] Create a `DbParams` for a database type (e.g. MSSQL) for which you have no driver - a warning should be shown
+ [x] Try to connect to a database using a password_variable that is not set.  It should log an error and raise exception.
+ [x] Include invalid parameters (e.g. filename) when creating the class.  It should raise an exception.
+ [x] Try to add invalid parameters to an existing class (e.g. BGSDEV.my_param='foo').  It should raise an exception.