### PR TITLE
Use fast_executemany option of pyODBC for MS SQL Server access

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,33 @@ conn4 = connect(ORACLEDB, 'ORACLE_PASSWORD', encoding="UTF-8", nencoding="UTF8")
 
 The above is a solution when special characters are scrambled in the returned data.
 
+#### Disabling fast_executemany for SQL Server and other pyODBC connections
+
+By default an `etlhelper` pyODBC connection uses a cursor with its
+`fast_executemany` attribute set to True. This setting improves the
+performance of the `executemany` when performing bulk inserts to a
+SQL Server database. However, this overides the default behaviour
+of pyODBC and there are some limitations in doing this. Importantly,
+it is only recommended for applications that use Microsoft's ODBC Driver for
+SQL Server. See [pyODBC fast_executemany](https://github.com/mkleehammer/pyodbc/wiki/Features-beyond-the-DB-API#fast_executemany).
+
+Within this limited use, `fast_executemany` may raise a `MemoryError` with the
+deprecated column types `TEXT` and `NTEXT`. `etlhelper` tries to handle this
+and, under these circumstances, falls back on `fast_executemany` being set to
+False with a warning output. See [Inserting into SQL server with
+fast_executemany results in MemoryError](https://github.com/mkleehammer/pyodbc/issues/547).
+
+Due to these limitations, if different driver is being used, or there are
+database errors, the `fast_executemany` attribute can be set to False via the
+`connect` function:
+
+```python
+conn5 = connect(MSSQLDB, 'MSSQL_PASSWORD', fast_executemany=False)
+```
+
+This keyword argument is used by `etlhelper`, any further keyword arguments are
+passed to the `connect` function of the underlying driver.
+
 ### Passwords
 
 Database passwords must be specified via an environment variable.

--- a/README.md
+++ b/README.md
@@ -175,21 +175,20 @@ The above is a solution when special characters are scrambled in the returned da
 #### Disabling fast_executemany for SQL Server and other pyODBC connections
 
 By default an `etlhelper` pyODBC connection uses a cursor with its
-`fast_executemany` attribute set to True. This setting improves the
+`fast_executemany` attribute set to `True`. This setting improves the
 performance of the `executemany` when performing bulk inserts to a
 SQL Server database. However, this overides the default behaviour
 of pyODBC and there are some limitations in doing this. Importantly,
 it is only recommended for applications that use Microsoft's ODBC Driver for
 SQL Server. See [pyODBC fast_executemany](https://github.com/mkleehammer/pyodbc/wiki/Features-beyond-the-DB-API#fast_executemany).
 
-Within this limited use, `fast_executemany` may raise a `MemoryError` with the
-deprecated column types `TEXT` and `NTEXT`. `etlhelper` tries to handle this
-and, under these circumstances, falls back on `fast_executemany` being set to
-False with a warning output. See [Inserting into SQL server with
+Using `fast_executemany` may raise a `MemoryError` if query involves columns of types
+`TEXT` and `NTEXT`, which are now deprecated.
+Under these circumstances, `etlhelper` falls back on `fast_executemany` being set to
+`False` and produces a warning output. See [Inserting into SQL server with
 fast_executemany results in MemoryError](https://github.com/mkleehammer/pyodbc/issues/547).
 
-Due to these limitations, if different driver is being used, or there are
-database errors, the `fast_executemany` attribute can be set to False via the
+If required, the `fast_executemany` attribute can be set to `False` via the
 `connect` function:
 
 ```python

--- a/etlhelper/db_helper_factory.py
+++ b/etlhelper/db_helper_factory.py
@@ -1,8 +1,10 @@
 """DB Helper factory
 
-Factory pattern that generates DbHelpers foreach DB type
+Factory pattern that generates a DbHelper for each DB type
 
 """
+from functools import lru_cache
+
 from etlhelper.db_helpers.oracle import OracleDbHelper
 from etlhelper.db_helpers.postgres import PostgresDbHelper
 from etlhelper.db_helpers.mssql import MSSQLDbHelper
@@ -51,6 +53,7 @@ class DbHelperFactory():
             raise ETLHelperHelperError(msg)
         return self.from_dbtype(dbtype)
 
+    @lru_cache(maxsize=16)
     def from_dbtype(self, dbtype):
         """
         Return initialised db helper based on type

--- a/etlhelper/db_helpers/mssql.py
+++ b/etlhelper/db_helpers/mssql.py
@@ -11,7 +11,7 @@ class MSSQLDbHelper(DbHelper):
     """
     def __init__(self):
         super().__init__()
-        self.required_params = {'host', 'port', 'dbname', 'user', 'odbc_driver', 'fast_executemany'}
+        self.required_params = {'host', 'port', 'dbname', 'user', 'odbc_driver'}
         self.missing_driver_msg = (
             "Could not import pyodbc module required for MS SQL connections.  "
             "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
@@ -25,8 +25,8 @@ class MSSQLDbHelper(DbHelper):
         except ImportError:
             warnings.warn(self.missing_driver_msg)
 
-    def connect(self, db_params, password_variable=None, **kwargs):
-        self.use_fast_executemany = (db_params.fast_executemany == 'true')
+    def connect(self, db_params, password_variable=None, fast_executemany=True, **kwargs):
+        self.use_fast_executemany = fast_executemany
         return super().connect(db_params, password_variable, **kwargs)
 
     def get_connection_string(self, db_params, password_variable):

--- a/etlhelper/db_helpers/mssql.py
+++ b/etlhelper/db_helpers/mssql.py
@@ -64,7 +64,8 @@ class MSSQLDbHelper(DbHelper):
             cursor.executemany(query, chunk)
         except MemoryError:
             warnings.warn(
-                "Failed to use fast_executemany for MS SQL connection.  "
-                "See https://github.com/BritishGeologicalSurvey/etlhelper for more information")
+                "fast_executemany execution failed.  Retrying with default executemany.  "
+                "See https://github.com/BritishGeologicalSurvey/etlhelper/issues/86 for more information"
+            )
             cursor.fast_executemany = False
             cursor.executemany(query, chunk)

--- a/etlhelper/db_helpers/mssql.py
+++ b/etlhelper/db_helpers/mssql.py
@@ -11,7 +11,7 @@ class MSSQLDbHelper(DbHelper):
     """
     def __init__(self):
         super().__init__()
-        self.required_params = {'host', 'port', 'dbname', 'user', 'odbc_driver'}
+        self.required_params = {'host', 'port', 'dbname', 'user', 'odbc_driver', 'fast_executemany'}
         self.missing_driver_msg = (
             "Could not import pyodbc module required for MS SQL connections.  "
             "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
@@ -21,8 +21,13 @@ class MSSQLDbHelper(DbHelper):
             self.connect_exceptions = (pyodbc.DatabaseError, pyodbc.InterfaceError)
             self.paramstyle = pyodbc.paramstyle
             self._connect_func = pyodbc.connect
+            self.use_fast_executemany = True
         except ImportError:
             warnings.warn(self.missing_driver_msg)
+
+    def connect(self, db_params, password_variable=None, **kwargs):
+        self.use_fast_executemany = (db_params.fast_executemany == 'true')
+        return super().connect(db_params, password_variable, **kwargs)
 
     def get_connection_string(self, db_params, password_variable):
         """
@@ -45,3 +50,21 @@ class MSSQLDbHelper(DbHelper):
         return (f'mssql+pyodbc://{db_params.user}:{password}@'
                 f'{db_params.host}:{db_params.port}/{db_params.dbname}?'
                 f'driver={driver}')
+
+    def executemany(self, cursor, query, chunk):
+        """
+        Try to use fast_executemany for SQL Server if flag in DbParams is set.
+
+        :param cursor: Open database cursor.
+        :param query: str, SQL query
+        :param chunk: list, Rows of parameters.
+        """
+        try:
+            cursor.fast_executemany = self.use_fast_executemany
+            cursor.executemany(query, chunk)
+        except MemoryError:
+            warnings.warn(
+                "Failed to use fast_executemany for MS SQL connection.  "
+                "See https://github.com/BritishGeologicalSurvey/etlhelper for more information")
+            cursor.fast_executemany = False
+            cursor.executemany(query, chunk)

--- a/test/integration/db/test_mssql.py
+++ b/test/integration/db/test_mssql.py
@@ -53,8 +53,8 @@ def test_bad_constraint(test_tables, testdb_conn):
         execute(insert_sql, testdb_conn)
 
 
-def test_copy_rows_happy_path(test_tables, testdb_conn, testdb_conn2,
-                              test_table_data):
+def test_copy_rows_happy_path_fast_true(
+        test_tables, testdb_conn, testdb_conn2, test_table_data):
     # Note: ODBC driver requires separate connections for source and destination,
     # even if they are the same database.
     # Arrange and act
@@ -65,7 +65,56 @@ def test_copy_rows_happy_path(test_tables, testdb_conn, testdb_conn2,
     # Assert
     sql = "SELECT * FROM dest"
     result = get_rows(sql, testdb_conn)
+    assert result == test_table_data
 
+
+def test_copy_rows_happy_path_deprecated_tables_fast_true(
+        test_deprecated_tables, testdb_conn, testdb_conn2, test_table_data):
+    # Note: ODBC driver requires separate connections for source and destination,
+    # even if they are the same database.
+    # Arrange and act
+    select_sql = "SELECT * FROM src"
+    insert_sql = INSERT_SQL.format(tablename='dest')
+    with pytest.warns(UserWarning) as record:
+        copy_rows(select_sql, testdb_conn, insert_sql, testdb_conn2)
+
+    # Assert
+    assert len(record) == 1
+    assert str(record[0].message).startswith(
+        "Failed to use fast_executemany for MS SQL connection.")
+
+    sql = "SELECT * FROM dest"
+    result = get_rows(sql, testdb_conn)
+    assert result == test_table_data
+
+
+def test_copy_rows_happy_path_fast_false(
+        test_tables, testdb_fast_false_conn, testdb_fast_false_conn2, test_table_data):
+    # Note: ODBC driver requires separate connections for source and destination,
+    # even if they are the same database.
+    # Arrange and act
+    select_sql = "SELECT * FROM src"
+    insert_sql = INSERT_SQL.format(tablename='dest')
+    copy_rows(select_sql, testdb_fast_false_conn, insert_sql, testdb_fast_false_conn2)
+
+    # Assert
+    sql = "SELECT * FROM dest"
+    result = get_rows(sql, testdb_fast_false_conn)
+    assert result == test_table_data
+
+
+def test_copy_rows_happy_path_deprecated_tables_fast_false(
+        test_deprecated_tables, testdb_fast_false_conn, testdb_fast_false_conn2, test_table_data):
+    # Note: ODBC driver requires separate connections for source and destination,
+    # even if they are the same database.
+    # Arrange and act
+    select_sql = "SELECT * FROM src"
+    insert_sql = INSERT_SQL.format(tablename='dest')
+    copy_rows(select_sql, testdb_fast_false_conn, insert_sql, testdb_fast_false_conn2)
+
+    # Assert
+    sql = "SELECT * FROM dest"
+    result = get_rows(sql, testdb_fast_false_conn)
     assert result == test_table_data
 
 
@@ -120,7 +169,74 @@ def testdb_conn2():
 
 
 @pytest.fixture(scope='function')
+def testdb_fast_false_conn():
+    """Get connection to test MS SQL database."""
+    MSSQLDB.fast_executemany = 'false'
+    with connect(MSSQLDB, 'TEST_MSSQL_PASSWORD') as conn:
+        return conn
+
+
+@pytest.fixture(scope='function')
+def testdb_fast_false_conn2():
+    """Get connection to test MS SQL database."""
+    MSSQLDB.fast_executemany = 'false'
+    with connect(MSSQLDB, 'TEST_MSSQL_PASSWORD') as conn:
+        return conn
+
+
+@pytest.fixture(scope='function')
 def test_tables(test_table_data, testdb_conn):
+    """
+    Create a table and fill with test data.  Teardown after the yield drops it
+    again.
+    """
+    # Define SQL queries
+    drop_src_sql = "DROP TABLE src"
+    create_src_sql = dedent("""
+        CREATE TABLE src
+          (
+            id integer unique,
+            value double precision,
+            simple_text nvarchar(max),
+            utf8_text nvarchar(max),
+            day date,
+            date_time datetime2(6)
+          )
+          ;""").strip()
+    drop_dest_sql = drop_src_sql.replace('src', 'dest')
+    create_dest_sql = create_src_sql.replace('src', 'dest')
+
+    # Create table and populate with test data
+    with testdb_conn.cursor() as cursor:
+        # src table
+        try:
+            cursor.execute(drop_src_sql)
+        except pyodbc.DatabaseError:
+            pass
+        cursor.execute(create_src_sql)
+        cursor.executemany(INSERT_SQL.format(tablename='src'),
+                           test_table_data)
+        # dest table
+        try:
+            cursor.execute(drop_dest_sql)
+        except pyodbc.DatabaseError:
+            # Error if table doesn't exist
+            pass
+        cursor.execute(create_dest_sql)
+    testdb_conn.commit()
+
+    # Return control to calling function until end of test
+    yield
+
+    # Tear down the table after test completes
+    with testdb_conn.cursor() as cursor:
+        cursor.execute(drop_src_sql)
+        cursor.execute(drop_dest_sql)
+    testdb_conn.commit()
+
+
+@pytest.fixture(scope='function')
+def test_deprecated_tables(test_table_data, testdb_conn):
     """
     Create a table and fill with test data.  Teardown after the yield drops it
     again.

--- a/test/integration/db/test_mssql.py
+++ b/test/integration/db/test_mssql.py
@@ -81,7 +81,7 @@ def test_copy_rows_happy_path_deprecated_tables_fast_true(
     # Assert
     assert len(record) == 1
     assert str(record[0].message).startswith(
-        "Failed to use fast_executemany for MS SQL connection.")
+        "fast_executemany execution failed")
 
     sql = "SELECT * FROM dest"
     result = get_rows(sql, testdb_conn)

--- a/test/integration/db/test_mssql.py
+++ b/test/integration/db/test_mssql.py
@@ -171,16 +171,14 @@ def testdb_conn2():
 @pytest.fixture(scope='function')
 def testdb_fast_false_conn():
     """Get connection to test MS SQL database."""
-    MSSQLDB.fast_executemany = 'false'
-    with connect(MSSQLDB, 'TEST_MSSQL_PASSWORD') as conn:
+    with connect(MSSQLDB, 'TEST_MSSQL_PASSWORD', fast_executemany=False) as conn:
         return conn
 
 
 @pytest.fixture(scope='function')
 def testdb_fast_false_conn2():
     """Get connection to test MS SQL database."""
-    MSSQLDB.fast_executemany = 'false'
-    with connect(MSSQLDB, 'TEST_MSSQL_PASSWORD') as conn:
+    with connect(MSSQLDB, 'TEST_MSSQL_PASSWORD', fast_executemany=False) as conn:
         return conn
 
 

--- a/test/unit/test_db_helpers.py
+++ b/test/unit/test_db_helpers.py
@@ -123,7 +123,7 @@ def test_connect_without_driver_raises_exception(db_params, driver, monkeypatch)
     DB_HELPER_FACTORY.from_dbtype.cache_clear()
 
     # Act and assert
-    with pytest.raises(ETLHelperConnectionError) as excinfo:
+    with pytest.warns(UserWarning), pytest.raises(ETLHelperConnectionError) as excinfo:
         db_params.connect('PASSWORD_VARIABLE')
 
     # Confirm error message includes driver details

--- a/test/unit/test_db_helpers.py
+++ b/test/unit/test_db_helpers.py
@@ -73,6 +73,7 @@ def test_connect(monkeypatch, db_params, driver, expected):
     monkeypatch.setenv('DB_PASSWORD', 'mypassword')
     mock_connect = Mock()
     monkeypatch.setattr(driver, 'connect', mock_connect)
+    DB_HELPER_FACTORY.from_dbtype.cache_clear()
     helper = DB_HELPER_FACTORY.from_db_params(db_params)
 
     # Act
@@ -119,6 +120,7 @@ def test_connect_without_driver_raises_exception(db_params, driver, monkeypatch)
 
     monkeypatch.setattr(builtins, '__import__', raise_import_error)
     monkeypatch.setenv("PASSWORD_VARIABLE", "blahblahblah")
+    DB_HELPER_FACTORY.from_dbtype.cache_clear()
 
     # Act and assert
     with pytest.raises(ETLHelperConnectionError) as excinfo:


### PR DESCRIPTION
See #86 for underlying issue and discussion.

The flag to use `fast_executemany` is an optional keyword argument on the overridden `connect` method of the `MSSQLDbHelper`, the default value is True. In order to persist the attribute, if it is set, an `@lru_cache` has been used for in the `DbHelperFactory` for `DBHelper` instances.

The `MSSQLDbHelper` `executemany` method is also overridden to try to use this attribute and fallback on False if there is an error. The error will arise if deprecated column types `text` and `ntext` are used.

The expanded integration tests should cover all the above cases and the problem of monkeypatching cached helpers has been added to the unit tests.

+ [x] Check code changes look reasonable
+ [x] Tests all pass
+ [x] README section makes sense

Closes #86 


