### PR TITLE
Add comment on DNS hijacking test failure

### DIFF
--- a/test/integration/test_setup_oracle_client.py
+++ b/test/integration/test_setup_oracle_client.py
@@ -143,7 +143,11 @@ def test_zipfile_bad_url(tmp_path):
         _check_or_get_zipfile(file_location)
 
     # Assert
+    # Note: some internet service providers hijack DNS requests and will return
+    # an HTML file here.  In this situation the error message is:
+    # zip_location '/tmp/bad.url' is not a valid zip file
     assert str(exc.value) == "Server unreachable (Name or service not known)"
+
     assert not _check_install_status(install_dir, ld_library_prepend_script)
 
 


### PR DESCRIPTION
### Description

When I run tests from my home internet, the `test_zipfile_bad_url` test fails because my ISP returns an HTML file instead of an NXDOMAIN error.  I don't want to change the test, because I think the problem is my ISP, but I've added an extra comment as a reminder for when it happens again.

### To test

n/a