### PR TITLE
Update spatial ETL GeomFromText command

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ select_sql_oracle = """
 insert_sql_postgis = """
     INSERT INTO dest (id, geom) VALUES (
       %s,
-      ST_Transform(ST_GeomFromWKT(%s), 27700)
+      ST_Transform(ST_GeomFromText(%s, 4326), 27700)
     )
     """
 ```


### PR DESCRIPTION
This merge request fixes a simple typo in the spatial ETL recipe to use the correct GeomFromtText command.