### PR TITLE
Load function

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ database with Python.
 + `setup_oracle_client` script installs Oracle Instant Client on Linux systems
 + `DbParams` objects provide consistent way to connect to different database types (currently Oracle, PostgreSQL, SQLite and MS SQL Server)
 + `get_rows`, `iter_rows`, `fetchone` and other functions for querying database
-+ `execute` and `executemany` functions to insert data
-+ `copy_rows` to transfer data from one database to another
++ `execute`, `executemany`, and `load` functions to insert data
++ `copy_rows` and `copy_table_rows` to transfer data from one database to another
 + Support for parameterised queries and in-flight transformation of data
 + Output results as namedtuple or dictionary
 + Timestamped log messages for tracking long-running data transfers
@@ -347,24 +347,70 @@ with POSTGRESDB.connect('PGPASSWORD') as conn:
 print(result.id)
 ```
 
+### Copy table rows
+
+`copy_table_rows` provides a simple way to copy all the data from one table to
+another.
+
+```python
+from my_databases import POSTGRESDB, ORACLEDB
+from etlhelper import copy_table_rows
+
+with ORACLEDB.connect("ORA_PASSWORD") as src_conn:
+    with POSTGRESDB.connect("PG_PASSWORD") as dest_conn:
+	copy_table_rows('my_table', src_conn, dest_conn)
+```
+
+
+### Combining `iter_rows` with `load`
+
+For extra control selecting the data to be transferred, `iter_rows` can be
+combined with `load`.
+
+```python
+from my_databases import POSTGRESDB, ORACLEDB
+from etlhelper import iter_rows, load
+
+select_sql = """
+    SELECT id, name, value FROM my_table
+    WHERE value > :min_value
+"""
+
+with ORACLEDB.connect("ORA_PASSWORD") as src_conn:
+    with POSTGRESDB.connect("PG_PASSWORD") as dest_conn:
+        rows = iter_rows(select_sql, src_conn, parameters={'min_value': 99})
+	load('my_table', dest_conn, rows)
+```
+
 ### Copy rows
 
-Copy rows takes the results from a SELECT query and applies them as parameters
+Customising both queries gives the greatest control on data selection and loading.
+`copy_rows` takes the results from a SELECT query and applies them as parameters
 to an INSERT query.
 The source and destination tables must already exist.
+For example, here we use GROUP BY and WHERE in the SELECT query and insert extra
+auto-generated values via the INSERT query.
 
 ```python
 from my_databases import POSTGRESDB, ORACLEDB
 from etlhelper import copy_rows
 
-select_sql = "SELECT id, name FROM src"
-insert_sql = "INSERT INTO dest (id, name)
-              VALUES (%s, %s)"
+select_sql = """
+    SELECT
+      customer_id,
+      SUM (amount) AS total_amount
+    FROM payment
+    WHERE id > 1000
+    GROUP BY customer_id
+"""
+insert_sql = """
+    INSERT INTO dest (customer_id, total_amount, loaded_by, load_time)
+    VALUES (%s, %s, current_user, now())
+"""
 
-src_conn = ORACLEDB.connect("ORA_PASSWORD")
-dest_conn = POSTGRESDB.connect("PG_PASSWORD")
-
-copy_rows(select_sql, src_conn, insert_sql, dest_conn)
+with ORACLEDB.connect("ORA_PASSWORD") as src_conn:
+    with POSTGRESDB.connect("PG_PASSWORD") as dest_conn:
+        copy_rows(select_sql, src_conn, insert_sql, dest_conn)
 ```
 
 `parameters` can be passed to the SELECT query as before and the

--- a/etlhelper/__init__.py
+++ b/etlhelper/__init__.py
@@ -18,6 +18,7 @@ from etlhelper.etl import (
     iter_chunks,
     iter_rows,
     load,
+    copy_table_rows,
 )
 from etlhelper.connect import (
     connect,

--- a/etlhelper/__init__.py
+++ b/etlhelper/__init__.py
@@ -17,6 +17,7 @@ from etlhelper.etl import (
     get_rows,
     iter_chunks,
     iter_rows,
+    load,
 )
 from etlhelper.connect import (
     connect,

--- a/etlhelper/db_helpers/db_helper.py
+++ b/etlhelper/db_helpers/db_helper.py
@@ -16,9 +16,12 @@ class DbHelper(metaclass=ABCMeta):
     """
     sql_exceptions = None
     connect_exceptions = None
+    # The following are used to help create parameterized queries.  Although
+    # paramstyle is require by DBAPI2, most drivers support both a named and
+    # positional style.
     paramstyle = None
-    named_placeholder = None
-    positional_placeholder = None
+    named_paramstyle = None
+    positional_paramstyle = None
 
     @abstractmethod
     def __init__(self):

--- a/etlhelper/db_helpers/db_helper.py
+++ b/etlhelper/db_helpers/db_helper.py
@@ -17,6 +17,8 @@ class DbHelper(metaclass=ABCMeta):
     sql_exceptions = None
     connect_exceptions = None
     paramstyle = None
+    named_placeholder = None
+    positional_placeholder = None
 
     @abstractmethod
     def __init__(self):

--- a/etlhelper/db_helpers/mssql.py
+++ b/etlhelper/db_helpers/mssql.py
@@ -15,8 +15,8 @@ class MSSQLDbHelper(DbHelper):
         self.missing_driver_msg = (
             "Could not import pyodbc module required for MS SQL connections.  "
             "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
-        self.named_placeholder = None  # pyodbc doesn't support named parameters
-        self.positional_placeholder = 'qmark'
+        self.named_paramstyle = None  # pyodbc doesn't support named parameters
+        self.positional_paramstyle = 'qmark'
 
         try:
             import pyodbc

--- a/etlhelper/db_helpers/mssql.py
+++ b/etlhelper/db_helpers/mssql.py
@@ -15,6 +15,9 @@ class MSSQLDbHelper(DbHelper):
         self.missing_driver_msg = (
             "Could not import pyodbc module required for MS SQL connections.  "
             "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
+        self.named_placeholder = None  # pyodbc doesn't support named parameters
+        self.positional_placeholder = 'qmark'
+
         try:
             import pyodbc
             self.sql_exceptions = (pyodbc.DatabaseError)

--- a/etlhelper/db_helpers/oracle.py
+++ b/etlhelper/db_helpers/oracle.py
@@ -15,6 +15,9 @@ class OracleDbHelper(DbHelper):
         self.missing_driver_msg = (
             "Could not import cx_Oracle module required for Oracle connections.  "
             "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
+        self.named_placeholder = 'named'
+        self.positional_placeholder = 'numeric'
+
         try:
             import cx_Oracle
             self.sql_exceptions = (cx_Oracle.DatabaseError)

--- a/etlhelper/db_helpers/oracle.py
+++ b/etlhelper/db_helpers/oracle.py
@@ -15,8 +15,8 @@ class OracleDbHelper(DbHelper):
         self.missing_driver_msg = (
             "Could not import cx_Oracle module required for Oracle connections.  "
             "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
-        self.named_placeholder = 'named'
-        self.positional_placeholder = 'numeric'
+        self.named_paramstyle = 'named'
+        self.positional_paramstyle = 'numeric'
 
         try:
             import cx_Oracle

--- a/etlhelper/db_helpers/postgres.py
+++ b/etlhelper/db_helpers/postgres.py
@@ -15,8 +15,8 @@ class PostgresDbHelper(DbHelper):
         self.missing_driver_msg = (
             "Could not import psycopg2 module required for PostgreSQL connections.  "
             "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
-        self.named_placeholder = 'pyformat'
-        self.positional_placeholder = 'format'
+        self.named_paramstyle = 'pyformat'
+        self.positional_paramstyle = 'format'
 
         try:
             import psycopg2

--- a/etlhelper/db_helpers/postgres.py
+++ b/etlhelper/db_helpers/postgres.py
@@ -15,6 +15,9 @@ class PostgresDbHelper(DbHelper):
         self.missing_driver_msg = (
             "Could not import psycopg2 module required for PostgreSQL connections.  "
             "See https://github.com/BritishGeologicalSurvey/etlhelper for installation instructions")
+        self.named_placeholder = 'pyformat'
+        self.positional_placeholder = 'format'
+
         try:
             import psycopg2
             self.sql_exceptions = (psycopg2.ProgrammingError,

--- a/etlhelper/db_helpers/sqlite.py
+++ b/etlhelper/db_helpers/sqlite.py
@@ -16,8 +16,8 @@ class SQLiteDbHelper(DbHelper):
         self.missing_driver_msg = (
             "Could not import sqlite3 module required for SQLite connections.  "
             "Check Python configuration - this should be part of Standard Library.")
-        self.named_placeholder = 'named'
-        self.positional_placeholder = 'qmark'
+        self.named_paramstyle = 'named'
+        self.positional_paramstyle = 'qmark'
 
         try:
             import sqlite3

--- a/etlhelper/db_helpers/sqlite.py
+++ b/etlhelper/db_helpers/sqlite.py
@@ -16,6 +16,9 @@ class SQLiteDbHelper(DbHelper):
         self.missing_driver_msg = (
             "Could not import sqlite3 module required for SQLite connections.  "
             "Check Python configuration - this should be part of Standard Library.")
+        self.named_placeholder = 'named'
+        self.positional_placeholder = 'qmark'
+
         try:
             import sqlite3
             self.sql_exceptions = (sqlite3.OperationalError,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,7 @@ Fixtures for pytest.  Functions defined here can be passed as arguments to
 pytest tests.  scope parameter describes how often they are recreated e.g.
 once per module.
 """
+from collections import namedtuple
 import datetime as dt
 import os
 from pathlib import Path
@@ -80,13 +81,15 @@ def test_table_data():
     """
     Return list of tuples of test data
     """
+    Row = namedtuple('Row',
+                     'id, value, simple_text, utf8_text, day, date_time')
     data = [
-        (1, 1.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 7),
-         dt.datetime(2018, 12, 7, 13, 1, 59)),
-        (2, 2.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 8),
-         dt.datetime(2018, 12, 8, 13, 1, 59)),
-        (3, 2.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 9),
-         dt.datetime(2018, 12, 9, 13, 1, 59)),
+        Row(1, 1.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 7),
+            dt.datetime(2018, 12, 7, 13, 1, 59)),
+        Row(2, 2.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 8),
+            dt.datetime(2018, 12, 8, 13, 1, 59)),
+        Row(3, 2.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 9),
+            dt.datetime(2018, 12, 9, 13, 1, 59)),
     ]
     return data
 

--- a/test/integration/db/test_mssql.py
+++ b/test/integration/db/test_mssql.py
@@ -8,7 +8,15 @@ from textwrap import dedent
 import pyodbc
 import pytest
 
-from etlhelper import connect, get_rows, copy_rows, execute, DbParams, load
+from etlhelper import (
+    DbParams,
+    connect,
+    copy_rows,
+    copy_table_rows,
+    execute,
+    get_rows,
+    load,
+)
 from etlhelper.exceptions import (
     ETLHelperConnectionError,
     ETLHelperInsertError,
@@ -115,6 +123,19 @@ def test_copy_rows_happy_path_deprecated_tables_fast_false(
     # Assert
     sql = "SELECT * FROM dest"
     result = get_rows(sql, testdb_fast_false_conn)
+    assert result == test_table_data
+
+
+def test_copy_table_rows_happy_path_fast_true(
+        test_tables, testdb_conn, testdb_conn2, test_table_data):
+    # Note: ODBC driver requires separate connections for source and destination,
+    # even if they are the same database.
+    # Arrange and act
+    copy_table_rows('src', testdb_conn, testdb_conn2, target='dest')
+
+    # Assert
+    sql = "SELECT * FROM dest"
+    result = get_rows(sql, testdb_conn)
     assert result == test_table_data
 
 

--- a/test/integration/db/test_oracle.py
+++ b/test/integration/db/test_oracle.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 import cx_Oracle
 import pytest
 
-from etlhelper import connect, get_rows, copy_rows, execute, DbParams
+from etlhelper import connect, get_rows, copy_rows, execute, DbParams, load
 from etlhelper.exceptions import (
     ETLHelperConnectionError,
     ETLHelperInsertError,
@@ -92,6 +92,57 @@ def test_copy_rows_bad_param_style(test_tables, testdb_conn, test_table_data):
     insert_sql = BAD_PARAM_STYLE_SQL.format(tablename='dest')
     with pytest.raises(ETLHelperInsertError):
         copy_rows(select_sql, testdb_conn, insert_sql, testdb_conn)
+
+
+def test_load_named_tuples(testdb_conn, test_tables, test_table_data):
+    # Arrange
+    # Convert to plain tuples as ORACLE makes column names upper case
+    expected = [tuple(row) for row in test_table_data]
+
+    # Act
+    load('dest', testdb_conn, test_table_data)
+
+    # Assert
+    sql = "SELECT * FROM dest"
+    result = get_rows(sql, testdb_conn)
+
+    # Fix result date and datetime strings to native classes
+    fixed_dates = []
+    for row in result:
+        fixed_dates.append((
+            *row[:4],
+            row.DAY.date(),
+            row.DATE_TIME
+        ))
+
+    assert fixed_dates == expected
+
+
+def test_load_dicts(testdb_conn, test_tables, test_table_data):
+    # Arrange
+    # Convert to plain tuples as ORACLE makes column names upper case
+    expected = [tuple(row) for row in test_table_data]
+
+    # Arrange
+    data_as_dicts = [row._asdict() for row in test_table_data]
+
+    # Act
+    load('dest', testdb_conn, data_as_dicts)
+
+    # Assert
+    sql = "SELECT * FROM dest"
+    result = get_rows(sql, testdb_conn)
+
+    # Fix result date and datetime strings to native classes
+    fixed_dates = []
+    for row in result:
+        fixed_dates.append((
+            *row[:4],
+            row.DAY.date(),
+            row.DATE_TIME
+        ))
+
+    assert fixed_dates == expected
 
 
 # -- Fixtures here --

--- a/test/integration/db/test_oracle.py
+++ b/test/integration/db/test_oracle.py
@@ -8,7 +8,15 @@ from textwrap import dedent
 import cx_Oracle
 import pytest
 
-from etlhelper import connect, get_rows, copy_rows, execute, DbParams, load
+from etlhelper import (
+    DbParams,
+    connect,
+    copy_rows,
+    copy_table_rows,
+    execute,
+    get_rows,
+    load,
+)
 from etlhelper.exceptions import (
     ETLHelperConnectionError,
     ETLHelperInsertError,
@@ -58,6 +66,26 @@ def test_copy_rows_happy_path(test_tables, testdb_conn, test_table_data):
     select_sql = "SELECT * FROM src"
     insert_sql = INSERT_SQL.format(tablename='dest')
     copy_rows(select_sql, testdb_conn, insert_sql, testdb_conn)
+
+    # Assert
+    sql = "SELECT * FROM dest"
+    result = get_rows(sql, testdb_conn)
+
+    # Fix result date and datetime strings to native classes
+    fixed_dates = []
+    for row in result:
+        fixed_dates.append((
+            *row[:4],
+            row.DAY.date(),
+            row.DATE_TIME
+        ))
+
+    assert fixed_dates == test_table_data
+
+
+def test_copy_table_rows_happy_path(test_tables, testdb_conn, test_table_data):
+    # Arrange and act
+    copy_table_rows('src', testdb_conn, testdb_conn, target='dest')
 
     # Assert
     sql = "SELECT * FROM dest"

--- a/test/integration/db/test_sqlite.py
+++ b/test/integration/db/test_sqlite.py
@@ -9,7 +9,15 @@ from textwrap import dedent
 
 import pytest
 
-from etlhelper import connect, get_rows, copy_rows, execute, DbParams, load
+from etlhelper import (
+    DbParams,
+    connect,
+    copy_rows,
+    copy_table_rows,
+    execute,
+    get_rows,
+    load,
+)
 from etlhelper.exceptions import (
     ETLHelperConnectionError,
     ETLHelperInsertError,
@@ -61,6 +69,17 @@ def test_copy_rows_happy_path(test_tables, testdb_conn, test_table_data):
     select_sql = "SELECT * FROM src"
     insert_sql = INSERT_SQL.format(tablename='dest')
     copy_rows(select_sql, testdb_conn, insert_sql, testdb_conn)
+
+    # Assert
+    sql = "SELECT * FROM dest"
+    result = get_rows(sql, testdb_conn)
+
+    assert result == test_table_data
+
+
+def test_copy_table_rows_happy_path(test_tables, testdb_conn, test_table_data):
+    # Arrange and act
+    copy_table_rows('src', testdb_conn, testdb_conn, target='dest')
 
     # Assert
     sql = "SELECT * FROM dest"

--- a/test/integration/etl/test_etl_load.py
+++ b/test/integration/etl/test_etl_load.py
@@ -65,9 +65,22 @@ def test_insert_rows_bad_query(pgtestdb_conn, test_table_data):
         executemany(insert_sql, pgtestdb_conn, test_table_data)
 
 
-def test_load(pgtestdb_conn, pgtestdb_test_tables, test_table_data):
+def test_load_named_tuples(pgtestdb_conn, pgtestdb_test_tables, test_table_data):
     # Act
     load('dest', pgtestdb_conn, test_table_data)
+
+    # Assert
+    sql = "SELECT * FROM dest"
+    result = get_rows(sql, pgtestdb_conn)
+    assert result == test_table_data
+
+
+def test_load_dicts(pgtestdb_conn, pgtestdb_test_tables, test_table_data):
+    # Arrange
+    data_as_dicts = [row._asdict() for row in test_table_data]
+
+    # Act
+    load('dest', pgtestdb_conn, data_as_dicts)
 
     # Assert
     sql = "SELECT * FROM dest"

--- a/test/integration/etl/test_etl_load.py
+++ b/test/integration/etl/test_etl_load.py
@@ -3,7 +3,7 @@ the executemany call.  These are run against PostgreSQL."""
 # pylint: disable=unused-argument, missing-docstring
 import pytest
 
-from etlhelper import iter_rows, get_rows, executemany
+from etlhelper import iter_rows, get_rows, executemany, load
 from etlhelper.etl import ETLHelperInsertError
 
 
@@ -63,3 +63,13 @@ def test_insert_rows_bad_query(pgtestdb_conn, test_table_data):
     # Act and assert
     with pytest.raises(ETLHelperInsertError):
         executemany(insert_sql, pgtestdb_conn, test_table_data)
+
+
+def test_load(pgtestdb_conn, pgtestdb_test_tables, test_table_data):
+    # Act
+    load('dest', pgtestdb_conn, test_table_data)
+
+    # Assert
+    sql = "SELECT * FROM dest"
+    result = get_rows(sql, pgtestdb_conn)
+    assert result == test_table_data

--- a/test/integration/etl/test_etl_transform.py
+++ b/test/integration/etl/test_etl_transform.py
@@ -5,7 +5,7 @@ from datetime import datetime, date
 
 import pytest
 
-from etlhelper import iter_rows, copy_rows, get_rows
+from etlhelper import iter_rows, copy_rows, get_rows, copy_table_rows
 from etlhelper.row_factories import dict_row_factory
 
 
@@ -20,6 +20,17 @@ def test_copy_rows_happy_path(pgtestdb_conn, pgtestdb_test_tables,
     sql = "SELECT * FROM dest"
     result = iter_rows(sql, pgtestdb_conn)
     assert list(result) == test_table_data
+
+
+def test_copy_table_rows_happy_path(pgtestdb_conn, pgtestdb_test_tables,
+                                    pgtestdb_insert_sql, test_table_data):
+    # Arrange and act
+    copy_table_rows('src', pgtestdb_conn, pgtestdb_conn, target='dest')
+
+    # Assert
+    sql = "SELECT * FROM dest"
+    result = get_rows(sql, pgtestdb_conn)
+    assert result == test_table_data
 
 
 def transform_return_list(rows):


### PR DESCRIPTION
### Description

This pull request adds `load` and `copy_table_rows` functions to ETL Helper.  The `load` function provides a convenient way to do inserts as it auto-generates with INSERT statement given the name of a target table.  The `copy_table_rows` function provides a shorthand way to copy all the rows from one table to another.

This change required some behind-the-scenes tweaks to the DbHelper classes to add attributes for `named_placeholder` and `positional_placeholder`.  It turns out that, although the `paramstyle` attribute describes a placeholder syntax, you can have different placeholders depending on whether or not you are passing named arguments.

When updating the SQLite tests, I discovered that you can configure `sqlite3` to return datetimes, so I used that to simplify the tests, too.

Closes #108.

### To test

+ [ ] Confirm that all integration tests run and pass
+ [ ] Load CSV data to SQLite using the new example in the README