### PR TITLE
Add on_error handling to executemany and related methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ database with Python.
 + `get_rows`, `iter_rows`, `fetchone` and other functions for querying database
 + `execute`, `executemany`, and `load` functions to insert data
 + `copy_rows` and `copy_table_rows` to transfer data from one database to another
++ `on_error` function to process rows that fail to insert
 + Support for parameterised queries and in-flight transformation of data
 + Output results as namedtuple or dictionary
 + Timestamped log messages for tracking long-running data transfers
@@ -308,6 +309,22 @@ placeholders for the INSERT query (e.g. `%(id)s` instead of `%s` for
 PostgreSQL, `:id` instead of `:1` for Oracle).
 
 
+#### Transform
+
+The `transform` parameter allows passing of a function to transform the data
+before returning it.
+The function must take a list of rows and return a list of modified rows.
+See `copy_rows` for more details.
+
+
+#### Chunk size
+
+All data extraction functions use `iter_chunks` behind the scenes.
+This reads rows from the database in chunks to prevent them all being loaded
+into memory at once.
+The default `chunk_size` is 5000 and this can be set via keyword argument.
+
+
 ### Insert rows
 
 `execute` can be used to insert a single row or to execute other single
@@ -323,9 +340,10 @@ rows = [(1, 'value'), (2, 'another value')]
 insert_sql = "INSERT INTO some_table (col1, col2) VALUES (%s, %s)"
 
 with POSTGRESDB.connect('PGPASSWORD') as conn:
-    executemany(insert_sql, conn, rows)
+    executemany(insert_sql, conn, rows, chunk_size=1000)
 ```
 
+The `chunk_size` default is 5,000 and it can be set with a keyword argument.
 The `commit_chunks` flag defaults to `True`.
 This ensures that an error during a large data transfer doesn't require all the
 records to be sent again.
@@ -347,6 +365,55 @@ with POSTGRESDB.connect('PGPASSWORD') as conn:
 print(result.id)
 ```
 
+The `load` function is similar to `executemany` except that it autogenerates
+an insert query based on the data provided.
+
+
+#### Handling insert errors
+
+The default behaviour of `etlhelper` is to raise an exception on the first
+error and abort the transfer.
+Sometimes it is desirable to ignore the errors and to do something else with
+the failed rows.
+The `on_error` parameter allows a function to be passed that is applied to the
+failed rows of each chunk.
+The input is a list of (row, exception) tuples.
+
+Different examples are given here.  The simplest approach is to collect all the
+errors into a list to process at the end.
+
+```python
+errors = []
+executemany(sql, conn, rows, on_error=errors.extend)
+
+if errors:
+    do_something()
+```
+
+Errors can be logged to the `etlhelper` logger.
+
+```python
+from etlhelper import logger
+
+def log_errors(failed_rows):
+    for row, exception in failed_rows:
+        logger.error(exception)
+
+executemany(sql, conn, rows, on_error=log_errors)
+```
+
+The IDs of failed rows can be written to a file.
+
+```python
+def write_bad_ids(failed_rows):
+    with open('bad_ids.txt', 'at') as out_file:
+        for row, exception in failed_rows:
+            out_file.write(f"{row.id}\n")
+
+executemany(sql, conn, rows, on_error=write_bad_ids)
+```
+
+
 ### Copy table rows
 
 `copy_table_rows` provides a simple way to copy all the data from one table to
@@ -362,6 +429,8 @@ with ORACLEDB.connect("ORA_PASSWORD") as src_conn:
     with POSTGRESDB.connect("PG_PASSWORD") as dest_conn:
 	copy_table_rows('my_table', src_conn, dest_conn)
 ```
+
+The `chunk_size`, `commit_chunks` and `on_error` parameters can all be set.
 
 
 ### Combining `iter_rows` with `load`
@@ -416,7 +485,7 @@ with ORACLEDB.connect("ORA_PASSWORD") as src_conn:
 ```
 
 `parameters` can be passed to the SELECT query as before and the
-`commit_chunks` flag can be set.
+`commit_chunks`, `chunk_size` and `on_error` options can be set.
 
 
 ### Transform

--- a/etlhelper/db_helpers/postgres.py
+++ b/etlhelper/db_helpers/postgres.py
@@ -22,7 +22,8 @@ class PostgresDbHelper(DbHelper):
             import psycopg2
             self.sql_exceptions = (psycopg2.ProgrammingError,
                                    psycopg2.InterfaceError,
-                                   psycopg2.InternalError)
+                                   psycopg2.InternalError,
+                                   psycopg2.errors.UniqueViolation)
             self.connect_exceptions = (psycopg2.OperationalError)
             self.paramstyle = psycopg2.paramstyle
             self._connect_func = psycopg2.connect

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -3,7 +3,6 @@ Functions for transferring data in and out of databases.
 """
 from itertools import zip_longest, islice, chain
 import logging
-import re
 
 from etlhelper.row_factories import namedtuple_row_factory
 from etlhelper.db_helper_factory import DB_HELPER_FACTORY
@@ -228,62 +227,7 @@ def dump_rows(select_query, conn, output_func=print, parameters=(),
         output_func(row)
 
 
-def log_and_raise(query, conn, helper, chunk, exc, logger):
-    conn.rollback()
-    msg = (f"Failed to insert chunk: [{chunk[0]}, ..., {chunk[-1]}]\n"
-           f"SQL query raised an error.\n\n{query}\n\n"
-           f"Required paramstyle: {helper.paramstyle}\n\n{exc}\n")
-    logger.debug(msg)
-    raise ETLHelperInsertError(msg)
-
-
-def log_and_continue(query, conn, helper, chunk, exc, logger):
-    conn.commit()
-    msg = (f"Failed to insert chunk: [{chunk[0]}, ..., {chunk[-1]}]\n"
-           f"SQL query raised an error.\n\n{query}\n\n"
-           f"Required paramstyle: {helper.paramstyle}\n\n{exc}\n")
-    logger.error(msg)
-
-
-def execute_chunk(query, conn, cursor, helper, chunk, processed, on_error):
-    try:
-        # Show first row as example of data
-        if processed == 0:
-            logger.debug(f"First row: {chunk[0]}")
-
-        # Execute query
-        helper.executemany(cursor, query, chunk)
-        processed += len(chunk)
-
-    except helper.sql_exceptions as exc:
-        # Handle exceptions using on_error function
-        on_error(query, conn, helper, chunk, exc, logger)
-
-        # If exception not raised by on_error
-        # try to parse exc and re-run recursively
-        matches = re.findall(r'\(([^)]+)\)', exc.pgerror)
-        if matches and len(matches) == 2:
-            key, value = tuple(matches)
-        else:
-            msg = (f"Failed to insert chunk: [{chunk[0]}, ..., {chunk[-1]}]\n"
-                   f"SQL query raised an error.\n\n{query}\n\n"
-                   f"Required paramstyle: {helper.paramstyle}\n\n{exc}\n"
-                   f"And failed to continue\n")
-            logger.error(msg)
-            raise ETLHelperInsertError(msg)
-
-        while chunk:
-            row = chunk.pop(0)
-            if getattr(row, key) == int(value):
-                break
-
-        if chunk:
-            processed += execute_chunk(query, conn, cursor, helper, chunk, processed, on_error)
-
-    return processed
-
-
-def executemany(query, conn, rows, commit_chunks=True, on_error=log_and_raise):
+def executemany(query, conn, rows, commit_chunks=True):
     """
     Use query to insert/update data from rows to database at conn.  This
     method uses the executemany or execute_batch (PostgreSQL) commands to
@@ -300,7 +244,6 @@ def executemany(query, conn, rows, commit_chunks=True, on_error=log_and_raise):
     :param conn: dbapi connection
     :param rows: List of tuples containing data to be inserted/updated
     :param commit_chunks: bool, commit after each chunk has been inserted/updated
-    :param on_error: func, function to call if an exception is raised by helper
     :return row_count: int, number of rows inserted/updated
     """
     logger.info(f"Executing many (chunksize={CHUNKSIZE})")
@@ -311,11 +254,29 @@ def executemany(query, conn, rows, commit_chunks=True, on_error=log_and_raise):
 
     with helper.cursor(conn) as cursor:
         for chunk in _chunker(rows, CHUNKSIZE):
-            # Chunker pads to whole chunk with None; remove these
-            chunk = [row for row in chunk if row is not None]
             # Run query
-            processed += execute_chunk(query, conn, cursor, helper, chunk, processed, on_error)
-            logger.info(f'{processed} rows processed')
+            try:
+                # Chunker pads to whole chunk with None; remove these
+                chunk = [row for row in chunk if row is not None]
+
+                # Show first row as example of data
+                if processed == 0:
+                    logger.debug(f"First row: {chunk[0]}")
+
+                # Execute query
+                helper.executemany(cursor, query, chunk)
+                processed += len(chunk)
+
+            except helper.sql_exceptions as exc:
+                # Rollback to clear the failed transaction before any others can
+                # be # started.
+                conn.rollback()
+                msg = (f"SQL query raised an error.\n\n{query}\n\n"
+                       f"Required paramstyle: {helper.paramstyle}\n\n{exc}\n")
+                raise ETLHelperInsertError(msg)
+
+            logger.info(
+                f'{processed} rows processed')
 
             # Commit changes so far
             if commit_chunks:
@@ -331,7 +292,7 @@ def executemany(query, conn, rows, commit_chunks=True, on_error=log_and_raise):
 def copy_rows(select_query, source_conn, insert_query, dest_conn,
               parameters=(), row_factory=namedtuple_row_factory,
               transform=None, commit_chunks=True,
-              read_lob=False, on_error_raise=True):
+              read_lob=False):
     """
     Copy rows from source_conn to dest_conn.  select_query and insert_query
     specify the data to be transferred.
@@ -355,17 +316,12 @@ def copy_rows(select_query, source_conn, insert_query, dest_conn,
                       returns an iterable of rows (possibly of different shape)
     :param commit_chunks: bool, commit after each chunk (see executemany)
     :param read_lob: bool, convert Oracle LOB objects to strings
-    :param on_error_raise bool, raise exception on error
     """
     rows_generator = iter_rows(select_query, source_conn,
                                parameters=parameters, row_factory=row_factory,
                                transform=transform, read_lob=read_lob)
-    if on_error_raise:
-        executemany(insert_query, dest_conn, rows_generator,
-                    commit_chunks=commit_chunks)
-    else:
-        executemany(insert_query, dest_conn, rows_generator,
-                    commit_chunks=commit_chunks, on_error=log_and_continue)
+    executemany(insert_query, dest_conn, rows_generator,
+                commit_chunks=commit_chunks)
 
 
 def execute(query, conn, parameters=()):

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -301,7 +301,16 @@ def executemany(query, conn, rows, on_error=None, commit_chunks=True,
 
                 # Collect and process failed rows if on_error function provided
                 if on_error:
-                    failed_rows = _execute_by_row(query, conn, chunk)
+                    # Temporarily disable logging
+                    old_level = logger.level
+                    logger.setLevel(logging.ERROR)
+
+                    try:
+                        failed_rows = _execute_by_row(query, conn, chunk)
+                    finally:
+                        # Restore logging
+                        logger.setLevel(old_level)
+
                     failed += len(failed_rows)
                     logger.debug("Calling on_error function on %s failed rows",
                                  failed)

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -266,9 +266,6 @@ def executemany(query, conn, rows, on_error=None, commit_chunks=True):
         for chunk in _chunker(rows, CHUNKSIZE):
             # Run query
             try:
-                # Chunker pads to whole chunk with None; remove these
-                chunk = [row for row in chunk if row is not None]
-
                 # Show first row as example of data
                 if processed == 0:
                     logger.debug(f"First row: {chunk[0]}")
@@ -507,7 +504,10 @@ def _chunker(iterable, n_chunks, fillvalue=None):
     """
     # _chunker('ABCDEFG', 3, 'x') --> ABC DEF Gxx"
     args = [iter(iterable)] * n_chunks
-    return zip_longest(*args, fillvalue=fillvalue)
+    padded_chunk = zip_longest(*args, fillvalue=fillvalue)
+
+    # zip_longest pads to whole chunk with None; remove these before return
+    return [row for row in padded_chunk if row is not None]
 
 
 def _read_lob(rows):

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -280,7 +280,7 @@ def executemany(query, conn, rows, on_error=None, commit_chunks=True):
 
                 # Collect and process failed rows if on_error function provided
                 if on_error:
-                    failed_rows = _execute_by_row(cursor, query, chunk, helper)
+                    failed_rows = _execute_by_row(cursor, query, chunk, conn)
                     failed += len(failed_rows)
                     logger.debug("Calling on_error function on %s failed rows",
                                  failed)
@@ -305,7 +305,7 @@ def executemany(query, conn, rows, on_error=None, commit_chunks=True):
     logger.info(f'{processed} rows processed in total')
 
 
-def _execute_by_row(cursor, query, chunk, conn, helper):
+def _execute_by_row(cursor, query, chunk, conn):
     """
     Retry execution of rows individually and return failed rows along with
     their errors.  Successful inserts are committed.  This is because
@@ -315,9 +315,9 @@ def _execute_by_row(cursor, query, chunk, conn, helper):
     :param query: str, SQL command with placeholders for data
     :param chunk: list, list of row parameters
     :param conn: open dbapi connection, used for transactions
-    :param helper: DbHelper associated with cursor
     :returns failed_rows: list of (row, exception) tuples
     """
+    helper = DB_HELPER_FACTORY.from_conn(conn)
     FailedRow = namedtuple('FailedRow', 'row, exception')
     failed_rows = []
 

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -266,6 +266,9 @@ def executemany(query, conn, rows, on_error=None, commit_chunks=True):
         for chunk in _chunker(rows, CHUNKSIZE):
             # Run query
             try:
+                # Chunker pads to whole chunk with None; remove these
+                chunk = [row for row in chunk if row is not None]
+
                 # Show first row as example of data
                 if processed == 0:
                     logger.debug(f"First row: {chunk[0]}")
@@ -504,10 +507,7 @@ def _chunker(iterable, n_chunks, fillvalue=None):
     """
     # _chunker('ABCDEFG', 3, 'x') --> ABC DEF Gxx"
     args = [iter(iterable)] * n_chunks
-    padded_chunk = zip_longest(*args, fillvalue=fillvalue)
-
-    # zip_longest pads to whole chunk with None; remove these before return
-    return [row for row in padded_chunk if row is not None]
+    return zip_longest(*args, fillvalue=fillvalue)
 
 
 def _read_lob(rows):

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -517,10 +517,6 @@ def generate_insert_sql(table, row, conn):
     # Namedtuples use a query with positional placeholders
     if not hasattr(row, 'keys'):
         paramstyle = helper.positional_paramstyle
-        if not paramstyle:
-            msg = (f"Database connection ({str(conn.__class__)}) doesn't support positional parameters.  "
-                   "Pass data as dictionaries instead.")
-            raise ETLHelperInsertError(msg)
 
         # Convert namedtuple to dictionary to easily access keys
         try:

--- a/etlhelper/exceptions.py
+++ b/etlhelper/exceptions.py
@@ -29,3 +29,19 @@ class ETLHelperInsertError(ETLHelperError):
 
 class ETLHelperHelperError(ETLHelperError):
     """Exception raised when helper selection fails."""
+
+
+def log_and_raise(chunk, query, helper, exc, logger, conn):
+    conn.rollback()
+    msg = (f"Failed to insert chunk: [{chunk[0]}, ..., {chunk[-1]}]\n"
+           f"SQL query raised an error.\n\n{query}\n\n"
+           f"Required paramstyle: {helper.paramstyle}\n\n{exc}\n")
+    logger.debug(msg)
+    raise ETLHelperInsertError(msg)
+
+
+def log_and_continue(chunk, query, helper, exc, logger, conn):
+    msg = (f"Failed to insert chunk: [{chunk[0]}, ..., {chunk[-1]}]\n"
+           f"SQL query raised an error.\n\n{query}\n\n"
+           f"Required paramstyle: {helper.paramstyle}\n\n{exc}\n")
+    logger.error(msg)

--- a/etlhelper/exceptions.py
+++ b/etlhelper/exceptions.py
@@ -29,19 +29,3 @@ class ETLHelperInsertError(ETLHelperError):
 
 class ETLHelperHelperError(ETLHelperError):
     """Exception raised when helper selection fails."""
-
-
-def log_and_raise(chunk, query, helper, exc, logger, conn):
-    conn.rollback()
-    msg = (f"Failed to insert chunk: [{chunk[0]}, ..., {chunk[-1]}]\n"
-           f"SQL query raised an error.\n\n{query}\n\n"
-           f"Required paramstyle: {helper.paramstyle}\n\n{exc}\n")
-    logger.debug(msg)
-    raise ETLHelperInsertError(msg)
-
-
-def log_and_continue(chunk, query, helper, exc, logger, conn):
-    msg = (f"Failed to insert chunk: [{chunk[0]}, ..., {chunk[-1]}]\n"
-           f"SQL query raised an error.\n\n{query}\n\n"
-           f"Required paramstyle: {helper.paramstyle}\n\n{exc}\n")
-    logger.error(msg)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -46,7 +46,7 @@ def pgtestdb_test_tables(test_table_data, pgtestdb_conn, pgtestdb_insert_sql):
     create_src_sql = dedent("""
           CREATE TABLE src
             (
-              id integer,
+              id integer primary key,
               value double precision,
               simple_text text,
               utf8_text text,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -46,7 +46,7 @@ def pgtestdb_test_tables(test_table_data, pgtestdb_conn, pgtestdb_insert_sql):
     create_src_sql = dedent("""
           CREATE TABLE src
             (
-              id integer,
+              id integer primary key,
               value double precision,
               simple_text text,
               utf8_text text,
@@ -90,6 +90,26 @@ def test_table_data():
             dt.datetime(2018, 12, 8, 13, 1, 59)),
         Row(3, 2.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 9),
             dt.datetime(2018, 12, 9, 13, 1, 59)),
+    ]
+    return data
+
+
+@pytest.fixture(scope='module')
+def test_table_additional_data():
+    """
+    Return list of tuples of test data
+    """
+    Row = namedtuple('Row',
+                     'id, value, simple_text, utf8_text, day, date_time')
+    data = [
+        Row(2, 2.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 8),
+            dt.datetime(2018, 12, 8, 13, 1, 59)),
+        Row(3, 2.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 9),
+            dt.datetime(2018, 12, 9, 13, 1, 59)),
+        Row(4, 4.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 10),
+            dt.datetime(2018, 12, 10, 13, 1, 59)),
+        Row(5, 5.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 11),
+            dt.datetime(2018, 12, 11, 13, 1, 59)),
     ]
     return data
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -46,7 +46,7 @@ def pgtestdb_test_tables(test_table_data, pgtestdb_conn, pgtestdb_insert_sql):
     create_src_sql = dedent("""
           CREATE TABLE src
             (
-              id integer primary key,
+              id integer,
               value double precision,
               simple_text text,
               utf8_text text,
@@ -90,44 +90,6 @@ def test_table_data():
             dt.datetime(2018, 12, 8, 13, 1, 59)),
         Row(3, 2.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 9),
             dt.datetime(2018, 12, 9, 13, 1, 59)),
-    ]
-    return data
-
-
-@pytest.fixture(scope='module')
-def test_table_overlapping_data():
-    """
-    Return list of tuples of test data
-    """
-    Row = namedtuple('Row',
-                     'id, value, simple_text, utf8_text, day, date_time')
-    data = [
-        Row(1, 1.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 7),
-            dt.datetime(2018, 12, 7, 13, 1, 59)),
-        Row(2, 2.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 8),
-            dt.datetime(2018, 12, 8, 13, 1, 59)),
-        Row(3, 2.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 9),
-            dt.datetime(2018, 12, 9, 13, 1, 59)),
-        Row(4, 4.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 10),
-            dt.datetime(2018, 12, 10, 13, 1, 59)),
-        Row(5, 5.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 11),
-            dt.datetime(2018, 12, 11, 13, 1, 59)),
-    ]
-    return data
-
-
-@pytest.fixture(scope='module')
-def test_table_extra_data():
-    """
-    Return list of tuples of test data
-    """
-    Row = namedtuple('Row',
-                     'id, value, simple_text, utf8_text, day, date_time')
-    data = [
-        Row(4, 4.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 10),
-            dt.datetime(2018, 12, 10, 13, 1, 59)),
-        Row(5, 5.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 11),
-            dt.datetime(2018, 12, 11, 13, 1, 59)),
     ]
     return data
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -95,7 +95,7 @@ def test_table_data():
 
 
 @pytest.fixture(scope='module')
-def test_table_additional_data():
+def test_table_overlapping_data():
     """
     Return list of tuples of test data
     """
@@ -108,6 +108,22 @@ def test_table_additional_data():
             dt.datetime(2018, 12, 8, 13, 1, 59)),
         Row(3, 2.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 9),
             dt.datetime(2018, 12, 9, 13, 1, 59)),
+        Row(4, 4.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 10),
+            dt.datetime(2018, 12, 10, 13, 1, 59)),
+        Row(5, 5.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 11),
+            dt.datetime(2018, 12, 11, 13, 1, 59)),
+    ]
+    return data
+
+
+@pytest.fixture(scope='module')
+def test_table_extra_data():
+    """
+    Return list of tuples of test data
+    """
+    Row = namedtuple('Row',
+                     'id, value, simple_text, utf8_text, day, date_time')
+    data = [
         Row(4, 4.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 10),
             dt.datetime(2018, 12, 10, 13, 1, 59)),
         Row(5, 5.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 11),

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -102,6 +102,8 @@ def test_table_additional_data():
     Row = namedtuple('Row',
                      'id, value, simple_text, utf8_text, day, date_time')
     data = [
+        Row(1, 1.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 7),
+            dt.datetime(2018, 12, 7, 13, 1, 59)),
         Row(2, 2.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 8),
             dt.datetime(2018, 12, 8, 13, 1, 59)),
         Row(3, 2.234, 'text', 'Öæ°\nz', dt.date(2018, 12, 9),

--- a/test/integration/db/test_oracle.py
+++ b/test/integration/db/test_oracle.py
@@ -136,7 +136,7 @@ def test_copy_table_rows_on_error(test_tables, testdb_conn, test_table_data):
     # changes the case of column names
     row, exception = errors[0]
     assert row.ID == 1
-    assert isinstance(exception, cx_Oracle.IntegrityError)
+    assert "unique" in str(exception).lower()
 
     # Check that other rows were inserted correctly
     assert fixed_dates[1:] == test_table_data[1:]

--- a/test/integration/db/test_sqlite.py
+++ b/test/integration/db/test_sqlite.py
@@ -88,6 +88,33 @@ def test_copy_table_rows_happy_path(test_tables, testdb_conn, test_table_data):
     assert result == test_table_data
 
 
+def test_copy_table_rows_on_error(test_tables, testdb_conn, test_table_data):
+    # Arrange
+    duplicate_id_row_sql = """
+       INSERT INTO dest (id)
+       VALUES (
+         1
+         )""".strip()
+    execute(duplicate_id_row_sql, testdb_conn)
+
+    # Act
+    errors = []
+    copy_table_rows('src', testdb_conn, testdb_conn, target='dest',
+                    on_error=errors.extend)
+
+    # Assert
+    sql = "SELECT * FROM dest"
+    result = get_rows(sql, testdb_conn)
+
+    # Check that first row was caught as error
+    row, exception = errors[0]
+    assert row.id == 1
+    assert "unique" in str(exception).lower()
+
+    # Check that other rows were inserted correctly
+    assert result[1:] == test_table_data[1:]
+
+
 def test_get_rows_with_parameters(test_tables, testdb_conn,
                                   test_table_data):
     # parameters=None is tested by default in other tests

--- a/test/integration/etl/test_etl_load.py
+++ b/test/integration/etl/test_etl_load.py
@@ -2,7 +2,7 @@
 the executemany call.  These are run against PostgreSQL."""
 # pylint: disable=unused-argument, missing-docstring
 import re
-from unittest.mock import sentinel, Mock, ANY, call
+from unittest.mock import sentinel, Mock, ANY
 
 from psycopg2.errors import UniqueViolation
 import pytest
@@ -143,7 +143,8 @@ def test_load_parameters_pass_to_executemany(monkeypatch, pgtestdb_conn,
     chunk_size = sentinel.chunk_size
 
     # Act
-    load(table, pgtestdb_conn, test_table_data, commit_chunks, chunk_size)
+    load(table, pgtestdb_conn, test_table_data, commit_chunks=commit_chunks,
+         chunk_size=chunk_size)
 
     # Assert
     # load() function writes SQL query
@@ -154,6 +155,6 @@ def test_load_parameters_pass_to_executemany(monkeypatch, pgtestdb_conn,
     sql = re.sub(r"\s\s+", " ", sql)  # replace newlines and whitespace
 
     mock_executemany.assert_called_once_with(
-        sql, pgtestdb_conn, ANY, commit_chunks=sentinel.commit_chunks,
+        sql, pgtestdb_conn, ANY, on_error=None,
+        commit_chunks=sentinel.commit_chunks,
         chunk_size=sentinel.chunk_size)
-

--- a/test/integration/etl/test_etl_load.py
+++ b/test/integration/etl/test_etl_load.py
@@ -4,7 +4,7 @@ the executemany call.  These are run against PostgreSQL."""
 import pytest
 
 from etlhelper import iter_rows, get_rows, executemany, load
-from etlhelper.etl import ETLHelperInsertError, log_and_continue, log_and_raise
+from etlhelper.etl import ETLHelperInsertError
 
 
 @pytest.mark.parametrize('commit_chunks', [True, False])
@@ -42,83 +42,6 @@ def test_insert_rows_chunked(pgtestdb_conn, pgtestdb_test_tables,
     assert result == test_table_data
 
 
-@pytest.mark.parametrize('chunk_size', [1, 2, 3, 4])
-def test_insert_rows_overlap_raise(pgtestdb_conn, pgtestdb_test_tables,
-                                   pgtestdb_insert_sql, test_table_data,
-                                   test_table_overlapping_data, monkeypatch,
-                                   chunk_size):
-    # Arrange
-    monkeypatch.setattr('etlhelper.etl.CHUNKSIZE', chunk_size)
-    insert_sql = pgtestdb_insert_sql.replace('src', 'dest')
-
-    # Act
-    executemany(insert_sql, pgtestdb_conn, test_table_data)
-    with pytest.raises(ETLHelperInsertError):
-        executemany(insert_sql, pgtestdb_conn, test_table_overlapping_data)
-
-    # Assert
-    sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
-    assert result == test_table_data
-
-
-@pytest.mark.parametrize('chunk_size', [1, 2, 3, 4, 5])
-def test_insert_rows_overlap_continue(pgtestdb_conn, pgtestdb_test_tables,
-                                      pgtestdb_insert_sql, test_table_data,
-                                      test_table_overlapping_data, monkeypatch,
-                                      chunk_size):
-    # Arrange
-    monkeypatch.setattr('etlhelper.etl.CHUNKSIZE', chunk_size)
-    insert_sql = pgtestdb_insert_sql.replace('src', 'dest')
-
-    # Act
-    executemany(insert_sql, pgtestdb_conn, test_table_data, on_error=log_and_continue)
-    executemany(insert_sql, pgtestdb_conn, test_table_overlapping_data, on_error=log_and_continue)
-
-    # Assert
-    sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
-    assert result == test_table_overlapping_data
-
-
-@pytest.mark.parametrize('chunk_size', [1, 2, 3, 4])
-def test_insert_rows_duplicate_continue(pgtestdb_conn, pgtestdb_test_tables,
-                                        pgtestdb_insert_sql, test_table_data, monkeypatch,
-                                        chunk_size):
-    # Arrange
-    monkeypatch.setattr('etlhelper.etl.CHUNKSIZE', chunk_size)
-    insert_sql = pgtestdb_insert_sql.replace('src', 'dest')
-
-    # Act
-    executemany(insert_sql, pgtestdb_conn, test_table_data, on_error=log_and_continue)
-    executemany(insert_sql, pgtestdb_conn, test_table_data, on_error=log_and_continue)
-
-    # Assert
-    sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
-    assert result == test_table_data
-
-
-@pytest.mark.parametrize('chunk_size', [1, 2, 3, 4])
-@pytest.mark.parametrize('on_error', [log_and_continue, log_and_raise])
-def test_insert_rows_no_overlap_continue(pgtestdb_conn, pgtestdb_test_tables,
-                                         pgtestdb_insert_sql, test_table_data,
-                                         test_table_extra_data, test_table_overlapping_data,
-                                         monkeypatch, chunk_size, on_error):
-    # Arrange
-    monkeypatch.setattr('etlhelper.etl.CHUNKSIZE', chunk_size)
-    insert_sql = pgtestdb_insert_sql.replace('src', 'dest')
-
-    # Act
-    executemany(insert_sql, pgtestdb_conn, test_table_data, on_error=on_error)
-    executemany(insert_sql, pgtestdb_conn, test_table_extra_data, on_error=on_error)
-
-    # Assert
-    sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
-    assert result == test_table_overlapping_data
-
-
 def test_insert_rows_no_rows(pgtestdb_conn, pgtestdb_test_tables,
                              pgtestdb_insert_sql, test_table_data):
     # Arrange
@@ -140,15 +63,6 @@ def test_insert_rows_bad_query(pgtestdb_conn, test_table_data):
     # Act and assert
     with pytest.raises(ETLHelperInsertError):
         executemany(insert_sql, pgtestdb_conn, test_table_data)
-
-
-def test_insert_rows_bad_query_continue(pgtestdb_conn, test_table_data):
-    # Arrange
-    insert_sql = "INSERT INTO bad_table VALUES (%s, %s, %s, %s, %s, %s)"
-
-    # Act and assert
-    with pytest.raises(ETLHelperInsertError):
-        executemany(insert_sql, pgtestdb_conn, test_table_data, on_error=log_and_continue)
 
 
 def test_load_named_tuples(pgtestdb_conn, pgtestdb_test_tables, test_table_data):

--- a/test/integration/etl/test_etl_load.py
+++ b/test/integration/etl/test_etl_load.py
@@ -4,7 +4,6 @@ the executemany call.  These are run against PostgreSQL."""
 import re
 from unittest.mock import sentinel, Mock, ANY
 
-from psycopg2.errors import UniqueViolation
 import pytest
 
 from etlhelper import iter_rows, get_rows, executemany, load
@@ -50,10 +49,10 @@ def test_insert_rows_on_error(pgtestdb_conn, pgtestdb_test_tables,
     result = get_rows(sql, pgtestdb_conn)
     assert result == test_table_data
 
-    # Assert error handling
+    # Assert full set of failed rows failing unique constraint
     failed_rows, exceptions = zip(*errors)
     assert set(failed_rows) == set(test_table_data)
-    assert set([type(e) for e in exceptions]) == {UniqueViolation}
+    assert all(['unique' in str(e).lower() for e in exceptions])
 
 
 @pytest.mark.parametrize('chunk_size', [1, 2, 3, 4])

--- a/test/integration/etl/test_etl_logging.py
+++ b/test/integration/etl/test_etl_logging.py
@@ -5,20 +5,19 @@ import pytest
 import re
 
 from etlhelper import copy_rows, execute, logger
-import etlhelper
 
 
 NO_OUTPUT = []
 INFO = [
-    'Executing many (chunksize=1)',
-    'Fetching rows',
+    'Executing many (chunk_size=1)',
+    'Fetching rows (chunk_size=1)',
     '1 rows processed (0 failed)',
     '2 rows processed (0 failed)',
     '3 rows processed (0 failed)',
     '3 rows returned',
     '3 rows processed in total']
 INFO_AND_DEBUG = [
-    'Executing many (chunksize=1)',
+    'Executing many (chunk_size=1)',
     'Executing:\n'
     '\n'
     'INSERT INTO dest (id, value, simple_text, utf8_text,\n'
@@ -31,7 +30,7 @@ INFO_AND_DEBUG = [
     '\n'
     "<connection object at ???; dsn: 'user=etlhelper_user password=xxx "
     "dbname=etlhelper host=??? port=???', closed: 0>",
-    'Fetching rows',
+    'Fetching rows (chunk_size=1)',
     'Fetching:\n'
     '\n'
     'SELECT * FROM src\n'
@@ -63,13 +62,14 @@ def test_logging_copy_rows(caplog, level, expected,
                            pgtestdb_conn, pgtestdb_test_tables,
                            pgtestdb_insert_sql, test_table_data):
     # Arrange
-    etlhelper.etl.CHUNKSIZE = 1
     caplog.set_level(level, logger=logger.name)
     select_sql = "SELECT * FROM src"
     insert_sql = pgtestdb_insert_sql.replace('src', 'dest')
 
     # Act
-    copy_rows(select_sql, pgtestdb_conn, insert_sql, pgtestdb_conn)
+    copy_rows(select_sql, pgtestdb_conn, insert_sql, pgtestdb_conn,
+              chunk_size=1)
+
     # ID for connection object and hostname vary between tests
     # and test environments
     messages = [re.sub(r'object at .*;', 'object at ???;', m)

--- a/test/integration/etl/test_etl_logging.py
+++ b/test/integration/etl/test_etl_logging.py
@@ -12,9 +12,9 @@ NO_OUTPUT = []
 INFO = [
     'Executing many (chunksize=1)',
     'Fetching rows',
-    '1 rows processed',
-    '2 rows processed',
-    '3 rows processed',
+    '1 rows processed (0 failed)',
+    '2 rows processed (0 failed)',
+    '3 rows processed (0 failed)',
     '3 rows returned',
     '3 rows processed in total']
 INFO_AND_DEBUG = [
@@ -47,9 +47,9 @@ INFO_AND_DEBUG = [
     "First row: Row(id=1, value=1.234, simple_text='text', utf8_text='Öæ°\\nz', "
     'day=datetime.date(2018, 12, 7), date_time=datetime.datetime(2018, 12, 7, 13, '
     '1, 59))',
-    '1 rows processed',
-    '2 rows processed',
-    '3 rows processed',
+    '1 rows processed (0 failed)',
+    '2 rows processed (0 failed)',
+    '3 rows processed (0 failed)',
     '3 rows returned',
     '3 rows processed in total']
 

--- a/test/unit/test_db_helpers.py
+++ b/test/unit/test_db_helpers.py
@@ -33,7 +33,7 @@ SQLITEDB = DbParams(dbtype='SQLITE', filename='/myfile.db')
     (OracleDbHelper, (cx_Oracle.DatabaseError)),
     (MSSQLDbHelper, (pyodbc.DatabaseError)),
     (PostgresDbHelper, (psycopg2.ProgrammingError, psycopg2.InterfaceError,
-                        psycopg2.InternalError)),
+                        psycopg2.InternalError, psycopg2.errors.UniqueViolation)),
     (SQLiteDbHelper, (sqlite3.OperationalError, sqlite3.IntegrityError))
 ])
 def test_sql_exceptions(helper, expected):


### PR DESCRIPTION
### Description

This merge request add the `on_error` parameter to `executemany`.  If a chunk raises an error then it will be retried as individual rows and the failing rows and their exceptions collected into a list.  The `on_error` function is then called on the list.

This provides a flexible way for users to handle failing rows in "real" time, as any function can be used.  The updated [README.md](README.md) has details.

Closes #91, which has much more discussion (and also #113, which is a bug-fix)

The changes also include making `chunk_size` a named parameter on many of the functions.  This makes it more convenient to change, rather than having to modify a module-level constant.

### To test

+ [x] Confirm that tests pass locally

To experiment, use the script below to test out inserting data to a SQLite database.  Try writing your own `on_error` functions.

```python
"""Script to create database and load observations data from csv file

Generate observations.csv with:
curl 'https://sensors.bgs.ac.uk/FROST-Server/v1.1/Observations?$select=@iot.id,result,phenomenonTime&$top=20000&$resultFormat=csv' -o observations.csv
"""
import csv
import datetime as dt
import sqlite3
from typing import Iterable

from etlhelper import execute, load, DbParams


def load_observations(csv_file, conn):
    """Load observations from csv_file to db_file."""
    # Drop table (helps with repeated test runs!
    drop_table_sql = """
        DROP TABLE observations
        """
    execute(drop_table_sql, conn)

    # Create table (reject ids with no remainder when divided by 1000)  
    create_table_sql = """
        CREATE TABLE IF NOT EXISTS observations (
          id INTEGER PRIMARY KEY CHECK (id % 1000),
          time TIMESTAMP,
          result FLOAT
          )"""
    execute(create_table_sql, conn)

    # Load data
    with open(csv_file, 'rt') as f:
        reader = csv.DictReader(f)
        load('observations', conn, transform(reader), on_error=on_error)


def on_error(failed_rows):
    """Print the IDs of failed rows"""
    rows, exceptions = zip(*failed_rows)
    failed_ids = [row['id'] for row in rows]
    print(f"Failed IDs: {failed_ids}")


# A transform function that takes an iterable and yields one row at a time
# returns a "generator".  The generator is also iterable, and records are
# processed as they are read so the whole file is never held in memory.
def transform(rows: Iterable[dict]) -> Iterable[dict]:
    """Rename time column and convert to Python datetime."""
    for row in rows:
        row['time'] = row.pop('phenomenonTime')
        row['time'] = dt.datetime.strptime(row['time'], "%Y-%m-%dT%H:%M:%S.%fZ")
        yield row


if __name__ == "__main__":
    import logging
    from etlhelper import logger
    logger.setLevel(logging.INFO)

    db = DbParams(dbtype="SQLITE", filename="observations.sqlite")
    with db.connect() as conn:
        load_observations('/tmp/observations.csv', conn)
```