### PR TITLE
Add test for empty generator

### DIFF
--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -509,10 +509,14 @@ def load(table, conn, rows, on_error=None, commit_chunks=True,
     if not rows:
         return 0, 0
 
-    # Get first row without losing it from row iteration
-    rows = iter(rows)
-    first_row = next(rows)
-    rows = chain([first_row], rows)
+    # Get first row without losing it from row iteration, returning early if
+    # the generator was empty.
+    try:
+        rows = iter(rows)
+        first_row = next(rows)  # This line throws the exception if empty
+        rows = chain([first_row], rows)
+    except StopIteration:
+        return 0, 0
 
     # Generate insert query
     query = generate_insert_sql(table, first_row, conn)

--- a/test/integration/etl/test_etl_load.py
+++ b/test/integration/etl/test_etl_load.py
@@ -139,7 +139,12 @@ def test_load_dicts(pgtestdb_conn, pgtestdb_test_tables, test_table_data):
     assert result == test_table_data
 
 
-@pytest.mark.parametrize('null_data', [None, [], ()])
+@pytest.mark.parametrize('null_data', [
+    None,
+    [],
+    (),
+    (item for item in ())  # empty generator
+    ])
 def test_load_no_data(pgtestdb_conn, pgtestdb_test_tables, null_data):
     # Act
     # Function should not crash when data are missing


### PR DESCRIPTION
The existing check for an empty set of rows (`if not rows`) doesn't
catch an empty generator.