### PR TITLE
Catch base classes for driver exceptions

### DIFF
--- a/etlhelper/db_helpers/mssql.py
+++ b/etlhelper/db_helpers/mssql.py
@@ -20,8 +20,10 @@ class MSSQLDbHelper(DbHelper):
 
         try:
             import pyodbc
-            self.sql_exceptions = (pyodbc.DatabaseError)
-            self.connect_exceptions = (pyodbc.DatabaseError, pyodbc.InterfaceError)
+            self.sql_exceptions = (pyodbc.DatabaseError,
+                                   pyodbc.InterfaceError)
+            self.connect_exceptions = (pyodbc.DatabaseError,
+                                       pyodbc.InterfaceError)
             self.paramstyle = pyodbc.paramstyle
             self._connect_func = pyodbc.connect
             self.use_fast_executemany = True

--- a/etlhelper/db_helpers/oracle.py
+++ b/etlhelper/db_helpers/oracle.py
@@ -20,8 +20,10 @@ class OracleDbHelper(DbHelper):
 
         try:
             import cx_Oracle
-            self.sql_exceptions = (cx_Oracle.DatabaseError)
-            self.connect_exceptions = (cx_Oracle.DatabaseError)
+            self.sql_exceptions = (cx_Oracle.DatabaseError,
+                                   cx_Oracle.InterfaceError)
+            self.connect_exceptions = (cx_Oracle.DatabaseError,
+                                       cx_Oracle.InterfaceError)
             self.paramstyle = cx_Oracle.paramstyle
             self._connect_func = cx_Oracle.connect
         except ImportError:

--- a/etlhelper/db_helpers/postgres.py
+++ b/etlhelper/db_helpers/postgres.py
@@ -20,11 +20,10 @@ class PostgresDbHelper(DbHelper):
 
         try:
             import psycopg2
-            self.sql_exceptions = (psycopg2.ProgrammingError,
-                                   psycopg2.InterfaceError,
-                                   psycopg2.InternalError,
-                                   psycopg2.errors.UniqueViolation)
-            self.connect_exceptions = (psycopg2.OperationalError)
+            self.sql_exceptions = (psycopg2.DatabaseError,
+                                   psycopg2.InterfaceError)
+            self.connect_exceptions = (psycopg2.DatabaseError,
+                                       psycopg2.InterfaceError)
             self.paramstyle = psycopg2.paramstyle
             self._connect_func = psycopg2.connect
         except ImportError:

--- a/etlhelper/db_helpers/sqlite.py
+++ b/etlhelper/db_helpers/sqlite.py
@@ -21,9 +21,10 @@ class SQLiteDbHelper(DbHelper):
 
         try:
             import sqlite3
-            self.sql_exceptions = (sqlite3.OperationalError,
-                                   sqlite3.IntegrityError)
-            self.connect_exceptions = (sqlite3.OperationalError)
+            self.sql_exceptions = (sqlite3.DatabaseError,
+                                   sqlite3.InterfaceError)
+            self.connect_exceptions = (sqlite3.DatabaseError,
+                                       sqlite3.InterfaceError)
             self.paramstyle = sqlite3.paramstyle
             self._connect_func = sqlite3.connect
         except ImportError:

--- a/test/unit/test_db_helpers.py
+++ b/test/unit/test_db_helpers.py
@@ -30,23 +30,26 @@ SQLITEDB = DbParams(dbtype='SQLITE', filename='/myfile.db')
 
 
 @pytest.mark.parametrize('helper, expected', [
-    (OracleDbHelper, (cx_Oracle.DatabaseError)),
-    (MSSQLDbHelper, (pyodbc.DatabaseError)),
-    (PostgresDbHelper, (psycopg2.ProgrammingError, psycopg2.InterfaceError,
-                        psycopg2.InternalError, psycopg2.errors.UniqueViolation)),
-    (SQLiteDbHelper, (sqlite3.OperationalError, sqlite3.IntegrityError))
+    (OracleDbHelper, (cx_Oracle.DatabaseError, cx_Oracle.InterfaceError)),
+    (MSSQLDbHelper, (pyodbc.DatabaseError, pyodbc.InterfaceError)),
+    (PostgresDbHelper, (psycopg2.DatabaseError, psycopg2.InterfaceError)),
+    (SQLiteDbHelper, (sqlite3.DatabaseError, sqlite3.InterfaceError))
 ])
 def test_sql_exceptions(helper, expected):
+    # DBAPI 2.0 specifies that all exceptions must inherit from DatabaseError
+    # or InterfaceError. See https://peps.python.org/pep-0249/#exceptions
     assert helper().sql_exceptions == expected
 
 
 @pytest.mark.parametrize('helper, expected', [
-    (OracleDbHelper, (cx_Oracle.DatabaseError)),
+    (OracleDbHelper, (cx_Oracle.DatabaseError, cx_Oracle.InterfaceError)),
     (MSSQLDbHelper, (pyodbc.DatabaseError, pyodbc.InterfaceError)),
-    (PostgresDbHelper, (psycopg2.OperationalError)),
-    (SQLiteDbHelper, (sqlite3.OperationalError))
+    (PostgresDbHelper, (psycopg2.DatabaseError, psycopg2.InterfaceError)),
+    (SQLiteDbHelper, (sqlite3.DatabaseError, sqlite3.InterfaceError))
 ])
 def test_connect_exceptions(helper, expected):
+    # DBAPI 2.0 specifies that all exceptions must inherit from DatabaseError
+    # or InterfaceError. See https://peps.python.org/pep-0249/#exceptions
     assert helper().connect_exceptions == expected
 
 


### PR DESCRIPTION
The DBAPI 2.0 specifies that all exceptions raised by the database
drivers must inherit from DatabaseError or Interface error.  Using those
as the exception classes caught by ETLHelper means that we don't need to
maintain a list of individual exception types for each different database.

https://peps.python.org/pep-0249/#exceptions