### PR TITLE
Add list and tuple row factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,16 @@ with ORACLEDB.connect("ORA_PASSWORD") as conn:
 #### Row factories
 
 Row factories control the output format of returned rows.
-To return each row as a dictionary, use the following:
+Four different versions are included:
+
+|Row Factory|Attribute access|Mutable|Parameter placeholder|
+|---|---|---|---|
+|namedtuple_row_factory (default)| `row.id` or `row[0]` | No | Positional |
+|dict_row_factory| `row["id"]`| Yes | Named |
+|tuple_row_factory| `row[0]`| No | Positional |
+|list_row_factory| `row[0]`| Yes | Positional |
+
+For example return each row as a dictionary, use the following:
 
 ```python
 from etlhelper import get_rows
@@ -303,11 +312,19 @@ with ORACLEDB.connect('ORACLE_PASSWORD') as conn:
         print(row['id'])
 ```
 
+Mutable rows can be convenient when used with transform functions because they
+can be modified without need to create a whole new output row.
+
+When using different row factories with `copy_rows`, it may be necessary to use
+different placeholder styles for parameters in the INSERT query.  The
+`dict_row_factory` requires named placeholders (e.g. `%(id)s` instead of `%s`
+ for PostgreSQL, `:id` instead of `:1` for Oracle).
+Using the `load` function requires that data are either named tuples or
+dictionaries.
+The `pyodbc` driver for MSSQL only supports positional placeholders.
+
 The `dict_row_factory` is useful when data are to be serialised to JSON/YAML,
-or when modifying individual fields with a `transform` function (see below).
-When using `dict_row_factory` with `copy_rows`, it is necessary to use named
-placeholders for the INSERT query (e.g. `%(id)s` instead of `%s` for
-PostgreSQL, `:id` instead of `:1` for Oracle).
+as those formats use dictionaries as input.
 
 
 #### Transform

--- a/etlhelper/row_factories.py
+++ b/etlhelper/row_factories.py
@@ -1,7 +1,6 @@
 """
-Functions that process row data as it comes from the database.  These are
-applied by the iter_rows function because the implementations for different
-database engines are different.
+Row factories are functions that process row data as it comes from the database.
+These are applied by the iter_rows function.
 
 A row_factory function must:
   + accept a cursor object as an input
@@ -15,7 +14,14 @@ import re
 
 
 def namedtuple_row_factory(cursor):
-    """Return output as a named tuple"""
+    """
+    Return function to convert output row to a named tuple.
+
+    Named tuples allow access to attributes via both position (e.g. row[0]) or
+    name (using dot notation, e.g. row.id).  They are immutable, so cannot be
+    modified directly in transform functions.  Insert statements based on named
+    tuples must use positional placeholders for parameters (e.g. ?, :1, %s).
+    """
     column_names = [d[0] for d in cursor.description]
 
     try:
@@ -36,7 +42,14 @@ def namedtuple_row_factory(cursor):
 
 
 def dict_row_factory(cursor):
-    """Replace the default tuple output with a dict"""
+    """
+    Return function to convert output row to a dictionary.
+
+    Dictionaries allow access to attributes via name (using key notation, e.g.
+    row["id"].  They are mutable, so are convenient to modify directly in
+    transform functions.  Insert statements based on dictionaries must use
+    named placeholders for parameters (e.g. :id, %(id)s).
+    """
     column_names = [d[0] for d in cursor.description]
 
     def create_row(row):
@@ -44,6 +57,39 @@ def dict_row_factory(cursor):
         for i, column_name in enumerate(column_names):
             row_dict[column_name] = row[i]
         return row_dict
+
+    return create_row
+
+
+def tuple_row_factory(cursor):
+    """
+    Return function to convert output row to a tuple.
+
+    Tuples allow access to attributes via position (e.g. row[0]).  They are
+    immutable, so cannot be modified directly in transform functions.  Insert
+    statements based on tuples must use positional placeholders for parameters
+    (e.g. ?, :1, %s).
+
+    As the DBAPI default is already to return rows as tuples, using the tuple
+    row factory minimises processing overhead.
+    """
+    def create_row(row):
+        return row
+
+    return create_row
+
+
+def list_row_factory(cursor):
+    """
+    Return function to convert output row to a list.
+
+    Lists allow access to attributes via position (e.g. row[0]).  They are
+    mutable, so are convient to modify directly in transform functions.  Insert
+    statements based on lists must use positional placeholders for parameters
+    (e.g. ?, :1, %s).
+    """
+    def create_row(row):
+        return list(row)
 
     return create_row
 


### PR DESCRIPTION
### Description

This merge request adds list and tuple row factories and updates the documentation.  It closes #132.

These changes mean that ETL Helper can export data in the main Python built-in collection types.  Adding the `list_row_factory` provides a mutable container for use with MS-SQL, which cannot use dictionaries.  Adding `tuple` gives an option with minimal processing overhead, although I haven't done any testing to see how much difference it makes.

### To test

+ [ ] Check the updated README makes sense
+ [ ] Confirm that the tests pass and are testing the correct thing