### PR TITLE
Abort function

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 > etlhelper is a Python library to simplify data transfer into and out of databases.
 
+> Note: There are a number of breaking changes planned for `etlhelper` version 1.0.
+> Please pin the version number in your dependency list to avoid disruption and
+> watch the project on GitHub for notification of new releases (in Custom section).
+
+
 ## Overview
 
 `etlhelper` makes it easy to run a SQL query via Python and return the results.

--- a/README.md
+++ b/README.md
@@ -560,6 +560,25 @@ a list.  Data transformation can then be performed via [memory-efficient
 iterator-chains](https://dbader.org/blog/python-iterator-chains).
 
 
+### Aborting running jobs
+
+When running as a script, `etlhelper` jobs can be stopped by pressing _CTRL-C_.
+This option is not available when the job is running as a background process,
+e.g. in a GUI application.
+The `abort_etlhelper_threads()` function is provided to cancel jobs running in
+a separate thread by raising an `ETLHelperAbort` exception within the thread.
+
+The state of the data when the job is cancelled (or crashes) depends on the
+arguments passed to `executemany` (or the functions that call it e.g. `load`,
+`copy_rows`).
+
++ If `commit_chunks` is `True` (default), all chunks up to the one where the
+  error occured are committed.
++ If `commit_chunks` is `False`, everything is rolled back and the database is
+  unchanged.
++ If an `on_error` function is defined, all rows without errors are committed.
+
+
 ## Utilities
 
 The following utility functions provide useful database metadata.

--- a/etlhelper/__init__.py
+++ b/etlhelper/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 # Import helper functions here for more convenient access
 # flake8: noqa
-from etlhelper.abort import abort
+from etlhelper.abort import abort_etlhelper_threads
 from etlhelper.db_params import DbParams
 from etlhelper.etl import (
     copy_rows,

--- a/etlhelper/__init__.py
+++ b/etlhelper/__init__.py
@@ -5,6 +5,7 @@ import logging
 
 # Import helper functions here for more convenient access
 # flake8: noqa
+from etlhelper.abort import abort
 from etlhelper.db_params import DbParams
 from etlhelper.etl import (
     copy_rows,

--- a/etlhelper/abort.py
+++ b/etlhelper/abort.py
@@ -8,7 +8,7 @@ from etlhelper.exceptions import ETLHelperAbort
 abort_event = threading.Event()
 
 
-def abort():
+def abort_etlhelper_threads():
     """
     Abort the ETLHelper process at the end of the current chunk.  During
     threaded operation, this will cause an ETLHelperAbort error to be

--- a/etlhelper/abort.py
+++ b/etlhelper/abort.py
@@ -1,0 +1,28 @@
+"""
+Functions used to handle aborts during threaded operations.
+"""
+import threading
+
+from etlhelper.exceptions import ETLHelperAbort
+
+abort_event = threading.Event()
+
+
+def abort():
+    """
+    Abort the ETLHelper process at the end of the current chunk.  During
+    threaded operation, this will cause an ETLHelperAbort error to be
+    raised.
+    """
+    abort_event.set()
+
+
+def clear_abort():
+    """Clear abort_event."""
+    abort_event.clear()
+
+
+def raise_for_abort(message):
+    """Raise EtlHelperAbort exception with message if abort_event is set."""
+    if abort_event.is_set():
+        raise ETLHelperAbort(message)

--- a/etlhelper/abort.py
+++ b/etlhelper/abort.py
@@ -17,7 +17,7 @@ def abort():
     abort_event.set()
 
 
-def clear_abort():
+def clear_abort_event():
     """Clear abort_event."""
     abort_event.clear()
 

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 from itertools import zip_longest, islice, chain
 import logging
 
-from etlhelper.abort import raise_for_abort
+from etlhelper.abort import raise_for_abort, clear_abort_event
 from etlhelper.row_factories import namedtuple_row_factory
 from etlhelper.db_helper_factory import DB_HELPER_FACTORY
 from etlhelper.exceptions import (
@@ -52,6 +52,8 @@ def iter_chunks(select_query, conn, parameters=(),
 
     helper = DB_HELPER_FACTORY.from_conn(conn)
     with helper.cursor(conn) as cursor:
+        clear_abort_event()
+
         # Run query
         try:
             cursor.execute(select_query, parameters)
@@ -69,6 +71,8 @@ def iter_chunks(select_query, conn, parameters=(),
         # Parse results
         first_pass = True
         while True:
+            raise_for_abort("abort() called during iter_chunks")
+
             rows = cursor.fetchmany(chunk_size)
 
             # No more rows to process

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 from itertools import zip_longest, islice, chain
 import logging
 
+from etlhelper.abort import raise_for_abort
 from etlhelper.row_factories import namedtuple_row_factory
 from etlhelper.db_helper_factory import DB_HELPER_FACTORY
 from etlhelper.exceptions import (

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -49,10 +49,10 @@ def iter_chunks(select_query, conn, parameters=(),
     logger.info("Fetching rows (chunk_size=%s)", chunk_size)
     logger.debug(f"Fetching:\n\n{select_query}\n\nwith parameters:\n\n"
                  f"{parameters}\n\nagainst\n\n{conn}")
+    clear_abort_event()
 
     helper = DB_HELPER_FACTORY.from_conn(conn)
     with helper.cursor(conn) as cursor:
-        clear_abort_event()
 
         # Run query
         try:
@@ -71,7 +71,7 @@ def iter_chunks(select_query, conn, parameters=(),
         # Parse results
         first_pass = True
         while True:
-            raise_for_abort("abort() called during iter_chunks")
+            raise_for_abort("abort_etlhelper_threads() called during iter_chunks")
 
             rows = cursor.fetchmany(chunk_size)
 
@@ -280,6 +280,7 @@ def executemany(query, conn, rows, on_error=None, commit_chunks=True,
     """
     logger.info("Executing many (chunk_size=%s)", chunk_size)
     logger.debug("Executing:\n\n%s\n\nagainst\n\n%s", query, conn)
+    clear_abort_event()
 
     helper = DB_HELPER_FACTORY.from_conn(conn)
     processed = 0
@@ -287,6 +288,8 @@ def executemany(query, conn, rows, on_error=None, commit_chunks=True,
 
     with helper.cursor(conn) as cursor:
         for chunk in _chunker(rows, chunk_size):
+            raise_for_abort("abort_etlhelper_threads() called during executemany")
+
             # Run query
             try:
                 # Chunker pads to whole chunk with None; remove these

--- a/etlhelper/exceptions.py
+++ b/etlhelper/exceptions.py
@@ -27,5 +27,9 @@ class ETLHelperInsertError(ETLHelperError):
     """Exception raised when inserting data."""
 
 
+class ETLHelperAbort(ETLHelperError):
+    """Exception raised when `abort` is called."""
+
+
 class ETLHelperHelperError(ETLHelperError):
     """Exception raised when helper selection fails."""

--- a/test/integration/etl/test_abort.py
+++ b/test/integration/etl/test_abort.py
@@ -2,18 +2,28 @@
 Tests for implementation of the abort() function in both extracting and
 loading data.
 """
-import queue
+from concurrent.futures import ThreadPoolExecutor
+import logging
 import sqlite3
-import threading
 from time import sleep
 
 import pytest
 
-from etlhelper import execute, executemany, load, fetchall, abort
+from etlhelper import execute, executemany, fetchall, abort
+from etlhelper.exceptions import ETLHelperAbort
+
+logger = logging.getLogger('abort_test')
+logger.setLevel(logging.INFO)
 
 
-def test_abort_on_fetchall(tmpdir):
+def test_abort_on_fetchall(tmpdir, caplog):
+    """
+    Fetch one row at a time from temporary database within a thread pool,
+    call abort() then assert that exception was raised and not all
+    rows were returned.
+    """
     # Arrange
+    # Create and populate a temporary SQLite database
     db = tmpdir / 'test.db'
 
     with sqlite3.connect(db) as conn:
@@ -22,21 +32,37 @@ def test_abort_on_fetchall(tmpdir):
         executemany("INSERT INTO test VALUES (?)", conn, rows=rows)
 
     def transform(chunk):
+        logger.info("Fetching row")
         # Add a delay to result fetching to give time for abort call
-        sleep(0.01)
+        sleep(0.1)
         return chunk
 
-    def do_fetchall(result_queue):
+    def do_etl():
         # Function to perform fetchall
         with sqlite3.connect(db) as conn:
             result = fetchall("SELECT * FROM test", conn,
                               transform=transform, chunk_size=1)
-            result_queue.put(result)
+        return result
 
     # Act
-    result_queue = queue.SimpleQueue()  # Thread-safe store for result
-    etl_thread = threading.Thread(target=do_fetchall, args=(result_queue,))
-    etl_thread.start()
+    # Do the ETL within a thread confirm it was aborted
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(do_etl)
 
-    # Assert
-    assert len(result_queue.get()) == 10
+        # Call abort after short delay
+        sleep(0.2)
+        abort()
+
+        # Exception raised when result is retrieved
+        with pytest.raises(ETLHelperAbort, match="iter_chunks"):
+            _ = future.result()
+
+    # The number of records is a proxy for the rows returned
+    assert len(caplog.records) < 10
+
+    # Redo the ETL without abort to confirm that abort event was cleared
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(do_etl)
+        result = future.result()
+
+    assert len(result) == 10

--- a/test/integration/etl/test_abort.py
+++ b/test/integration/etl/test_abort.py
@@ -24,21 +24,44 @@ logger.setLevel(logging.INFO)
 def do_fetchall_etl(db):
     # Example of a fetchall ETL job
 
-    def transform(chunk):
+    def log_chunks_slowly(chunk):
         logger.info("Processing chunk")
         # Add a delay to result fetching to give time for abort call
-        sleep(0.1)
+        sleep(0.05)
         return chunk
 
     with sqlite3.connect(db) as conn:
         result = fetchall("SELECT * FROM test", conn,
-                          transform=transform, chunk_size=1)
+                          transform=log_chunks_slowly, chunk_size=1)
 
     return result
 
 
-@pytest.mark.parametrize("do_etl", [do_fetchall_etl])
-def test_abort_etlhelper_threads(do_etl, tmpdir, caplog):
+def do_executemany_etl(db):
+    # Example of an executemany ETL job
+
+    # Create generator to produce rows with delay
+    def slow_row_generator(rows_generated):
+        for i in range(10):
+            sleep(0.05)
+            logger.info("Generating row")
+            row = (i,)
+            rows_generated.append(row)
+            yield row
+
+    rows_generated = []
+    with sqlite3.connect(db) as conn:
+        executemany("INSERT INTO test VALUES (?)", conn,
+                    slow_row_generator(rows_generated), chunk_size=1)
+
+    return rows_generated
+
+
+@pytest.mark.parametrize("do_etl, log_keyword", [
+    (do_fetchall_etl, 'iter_chunks'),
+    (do_executemany_etl, 'executemany')
+    ])
+def test_abort_etlhelper_threads(do_etl, log_keyword, tmpdir, caplog):
     """
     Transfer one row at a time to/from temporary database within a thread pool,
     call abort() then assert that exception was raised and not all rows were
@@ -63,7 +86,7 @@ def test_abort_etlhelper_threads(do_etl, tmpdir, caplog):
         abort_etlhelper_threads()
 
         # Exceptions from threads are raised when result is retrieved
-        with pytest.raises(ETLHelperAbort, match="iter_chunks"):
+        with pytest.raises(ETLHelperAbort, match=log_keyword):
             _ = future.result()
 
     # The number of log records is a proxy for the rows handled
@@ -71,7 +94,7 @@ def test_abort_etlhelper_threads(do_etl, tmpdir, caplog):
 
     # Redo the ETL without abort to confirm that abort event was cleared
     with ThreadPoolExecutor(max_workers=1) as executor:
-        future = executor.submit(do_etl)
+        future = executor.submit(do_etl, db)
         result = future.result()
 
     assert len(result) == 10

--- a/test/integration/etl/test_abort.py
+++ b/test/integration/etl/test_abort.py
@@ -1,0 +1,42 @@
+"""
+Tests for implementation of the abort() function in both extracting and
+loading data.
+"""
+import queue
+import sqlite3
+import threading
+from time import sleep
+
+import pytest
+
+from etlhelper import execute, executemany, load, fetchall, abort
+
+
+def test_abort_on_fetchall(tmpdir):
+    # Arrange
+    db = tmpdir / 'test.db'
+
+    with sqlite3.connect(db) as conn:
+        execute("CREATE TABLE test (id INTEGER)", conn)
+        rows = ((row,) for row in range(10))
+        executemany("INSERT INTO test VALUES (?)", conn, rows=rows)
+
+    def transform(chunk):
+        # Add a delay to result fetching to give time for abort call
+        sleep(0.01)
+        return chunk
+
+    def do_fetchall(result_queue):
+        # Function to perform fetchall
+        with sqlite3.connect(db) as conn:
+            result = fetchall("SELECT * FROM test", conn,
+                              transform=transform, chunk_size=1)
+            result_queue.put(result)
+
+    # Act
+    result_queue = queue.SimpleQueue()  # Thread-safe store for result
+    etl_thread = threading.Thread(target=do_fetchall, args=(result_queue,))
+    etl_thread.start()
+
+    # Assert
+    assert len(result_queue.get()) == 10

--- a/test/integration/etl/test_abort.py
+++ b/test/integration/etl/test_abort.py
@@ -9,14 +9,19 @@ from time import sleep
 
 import pytest
 
-from etlhelper import execute, executemany, fetchall, abort
+from etlhelper import (
+    abort_etlhelper_threads,
+    execute,
+    executemany,
+    fetchall,
+)
 from etlhelper.exceptions import ETLHelperAbort
 
 logger = logging.getLogger('abort_test')
 logger.setLevel(logging.INFO)
 
 
-def test_abort_on_fetchall(tmpdir, caplog):
+def test_abort_etlhelper_threads(tmpdir, caplog):
     """
     Fetch one row at a time from temporary database within a thread pool,
     call abort() then assert that exception was raised and not all
@@ -51,7 +56,7 @@ def test_abort_on_fetchall(tmpdir, caplog):
 
         # Call abort after short delay
         sleep(0.2)
-        abort()
+        abort_etlhelper_threads()
 
         # Exception raised when result is retrieved
         with pytest.raises(ETLHelperAbort, match="iter_chunks"):


### PR DESCRIPTION
### Description

This pull request adds an `abort_etlhelper_threads()` function that allows jobs to be cancelled from other threads.  This is useful for GUI applications that use ETLHelper.  It closes #124.

### To test

The abort code is relatively simple and the test code is actually more tricky.  It needs to use the ThreadPoolExecutor to run the jobs and capture exceptions that they raise.  They comments and description should make sense, but please modify if they don't.

+ [x] Confirm that all tests pass