### PR TITLE
Allow schema-qualified names in validate_identifier

### DIFF
--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -605,7 +605,9 @@ def validate_identifier(identifier):
     # `\w` represents all alphanumeric characters (including unicode) plus `_`
     # `(?![0-9])` is a "negative-lookahead assertion" to remove numbers from
     # the match for the first character.
-    regex = re.compile(r"(?![0-9])[\w][\w$]*$")
+    # The regex comprises two very similar groups.  The first is optional and
+    # ends with a dot.  This represents the schema name.
+    regex = re.compile(r"((?![0-9])[\w][\w$]*\.?)?((?![0-9])[\w][\w$]*)$")
 
     if not regex.match(identifier):
         msg = f"'{identifier}' contains invalid characters."

--- a/test/unit/test_etl.py
+++ b/test/unit/test_etl.py
@@ -13,6 +13,22 @@ from etlhelper.exceptions import ETLHelperBadIdentifierError
     "_starts_with_underscore",
     "has_numbers_123",
     "has_$",
+    # schema qualified table names with same rules
+    "schema.all_alpha",
+    "schema.ALL_CAPS_ALPHA",
+    "schema_123.þis_is_nøn_latîn_ælpha",
+    "schema.this_is_nøn_latîn_ælpha_except_first_character",
+    "schema._starts_with_underscore",
+    "schema.has_numbers_123",
+    "schema.has_$",
+    # rules also apply to schema names
+    "all_alpha.table",
+    "ALL_CAPS_ALPHA.table",
+    "þis_is_nøn_latîn_ælpha.table",
+    "this_is_nøn_latîn_ælpha_except_first_character.table",
+    "_starts_with_underscore.table",
+    "has_numbers_123.table",
+    "has_$.table",
 ])
 def test_validate_identifier_good(good_identifier):
     validate_identifier(good_identifier)
@@ -24,7 +40,13 @@ def test_validate_identifier_good(good_identifier):
     "123_starts_number",
     "$_starts_dollar",
     ";",
-    "()"
+    "()",
+    "schema.123_starts_number",
+    "schema.$_starts_dollar",
+    "123_starts_number.table",
+    "$_starts_dollar.table",
+    ";",
+    "()",
 ])
 def test_validate_identifier_bad(bad_identifier):
     with pytest.raises(ETLHelperBadIdentifierError):


### PR DESCRIPTION
This is a minor fix to allow schema-qualified table names e.g. "public.my_table" to pass validation.