### PR TITLE
159 add deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+setup_env.sh
 
 # Spyder project settings
 .spyderproject

--- a/etlhelper/__init__.py
+++ b/etlhelper/__init__.py
@@ -2,6 +2,7 @@
 Library to simplify data transfer between databases
 """
 import logging
+import warnings
 
 # Import helper functions here for more convenient access
 # flake8: noqa
@@ -33,6 +34,15 @@ from etlhelper.utils import (
 
 from . import _version
 __version__ = _version.get_versions()['version']
+
+warnings.warn(
+    (
+        "ETLHelper version 1.0.0 is coming soon and will contain deprecations. "
+        "Users should pin their versions and check GitHub issues for details."
+    ),
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 # Prepare log handler.  See this StackOverflow answer for details:
 # https://stackoverflow.com/a/27835318/3508733


### PR DESCRIPTION
### Description

This merge request adds a warning which is shown when ETLHelper is imported into a Python script:
`DeprecationWarning: ETLHelper version 1.0.0 is coming soon and will contain deprecations. Users should pin their versions and check GitHub issues for details.`

closes #159 