### PR TITLE
139 add transform option to load and executemany

### DIFF
--- a/test/integration/etl/test_etl_load.py
+++ b/test/integration/etl/test_etl_load.py
@@ -192,7 +192,8 @@ def test_load_parameters_pass_to_executemany(monkeypatch, pgtestdb_conn,
     sql = re.sub(r"\s\s+", " ", sql)  # replace newlines and whitespace
 
     mock_executemany.assert_called_once_with(
-        sql, pgtestdb_conn, ANY, on_error=None,
+        sql, pgtestdb_conn, ANY,
+        transform=None, on_error=None,
         commit_chunks=sentinel.commit_chunks,
         chunk_size=sentinel.chunk_size)
 


### PR DESCRIPTION
### Summary

A new argument has been added to both the `load` and `executemany` functions: `transform`.

### Description

This new argument has been implemented in accordance with the requirements in issue #139.

There has been a minor change which goes against the acceptance criteria. The new tests for the `transform` argument in the `load` function have been created in the `test/integration/etl/test_etl_transform.py` file, rather than the `test/integration/etl/test_etl_abort.py` file. This has been done because the new tests are for the `transform` functionality and have no interaction with the abort process.