### PR TITLE
125 refactor logging to add log to stderr function

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,10 @@ if errors:
 Errors can be logged to the `etlhelper` logger.
 
 ```python
-from etlhelper import logger
+import etlhelper
+
+logger = etlhelper.log_to_console()
+
 
 def log_errors(failed_rows):
     for row, exception in failed_rows:
@@ -655,15 +658,15 @@ The following recipes demonstrate how `etlhelper` can be used.
 
 ETL Helper provides a custom logging handler.
 Time-stamped messages indicating the number of rows processed can be enabled by
-setting the log level to INFO.
-Setting the level to DEBUG provides information on the query that was run,
+setting the log level to `INFO`.
+Setting the level to `DEBUG` provides information on the query that was run,
 example data and the database connection.
+To enable the logger, use:
 
 ```python
-import logging
-from etlhelper import logger
+import etlhelper
 
-logger.setLevel(logging.INFO)
+logger = etlhelper.log_to_console()
 ```
 
 Output from a call to `copy_rows` will look like:

--- a/etlhelper/__init__.py
+++ b/etlhelper/__init__.py
@@ -2,6 +2,9 @@
 Library to simplify data transfer between databases
 """
 import logging
+import sys
+
+from os import devnull
 
 # Import helper functions here for more convenient access
 # flake8: noqa
@@ -34,22 +37,38 @@ from etlhelper.utils import (
 from . import _version
 __version__ = _version.get_versions()['version']
 
-# Prepare log handler.  See this StackOverflow answer for details:
-# https://stackoverflow.com/a/27835318/3508733
-class CleanDebugMessageFormatter(logging.Formatter):
-    default_fmt = logging.Formatter('%(asctime)s %(funcName)s: %(message)s')
-    debug_fmt = logging.Formatter('%(message)s')
-
-    def format(self, record):
-        if record.levelno < logging.INFO:
-            return self.debug_fmt.format(record)
-        else:
-            return self.default_fmt.format(record)
-
-handler = logging.StreamHandler()
-handler.setFormatter(CleanDebugMessageFormatter())
-
-# Configure logger
+# Set default logger to not output
+handler = logging.StreamHandler(open(devnull, "w"))
 logger = logging.getLogger('etlhelper')
 logger.addHandler(handler)
-logger.setLevel(level=logging.WARN)
+
+
+def log_to_console(level=logging.INFO, output=sys.stderr) -> logging.Logger:
+    """
+    Log ETLHelper messages to the given output.
+
+    :param level: logger level
+    :param output: the output location of the logger messages
+    :return: the configured logger
+    :rtype: logging.Logger
+    """
+    # Prepare log handler.  See this StackOverflow answer for details:
+    # https://stackoverflow.com/a/27835318/3508733
+    class CleanDebugMessageFormatter(logging.Formatter):
+        default_fmt = logging.Formatter('%(asctime)s %(funcName)s: %(message)s')
+        debug_fmt = logging.Formatter('%(message)s')
+
+        def format(self, record):
+            if record.levelno < logging.INFO:
+                return self.debug_fmt.format(record)
+            else:
+                return self.default_fmt.format(record)
+
+    handler = logging.StreamHandler(output)
+    handler.setFormatter(CleanDebugMessageFormatter())
+
+    # Configure logger
+    logger = logging.getLogger('etlhelper')
+    logger.addHandler(handler)
+    logger.setLevel(level=level)
+    return logger

--- a/etlhelper/__init__.py
+++ b/etlhelper/__init__.py
@@ -4,8 +4,6 @@ Library to simplify data transfer between databases
 import logging
 import sys
 
-from os import devnull
-
 # Import helper functions here for more convenient access
 # flake8: noqa
 from etlhelper.abort import abort_etlhelper_threads
@@ -36,11 +34,6 @@ from etlhelper.utils import (
 
 from . import _version
 __version__ = _version.get_versions()['version']
-
-# Set default logger to not output
-handler = logging.StreamHandler(open(devnull, "w"))
-logger = logging.getLogger('etlhelper')
-logger.addHandler(handler)
 
 
 def log_to_console(level=logging.INFO, output=sys.stderr) -> logging.Logger:


### PR DESCRIPTION
This merge request adds the function `log_to_console`, which allows users to enable and modify the `etlhelper` logging handler, as specified by issue #125.

Closes #125 