### PR TITLE
Add row_factories import to __init__

### DIFF
--- a/etlhelper/__init__.py
+++ b/etlhelper/__init__.py
@@ -31,6 +31,9 @@ from etlhelper.connect import (
 from etlhelper.utils import (
     table_info,
 )
+from etlhelper import (
+    row_factories,
+)
 
 from . import _version
 __version__ = _version.get_versions()['version']


### PR DESCRIPTION
### Summary

This merge request fixes a small issue which helps code editors to provide productivity improvements for `etlhelper.row_factories`.

### Description

Currently, `etlhelper.row_factories` is accessed directly from `etlhelper/row_factories.py`, it is not imported in any `__init__` files. Whilst the submodule is accessible, code editors (e.g., VSCode) cannot provide productivity improvements for this submodule:

![image](https://github.com/BritishGeologicalSurvey/etlhelper/assets/116461518/e2f54023-0edf-4a04-826a-cf30255c9438)

To solve this, the following has been done:
- Add `from etlhelper import row_factories` to `etlhelper/__init__.py`