### PR TITLE
Change column type to lowercase

### DIFF
--- a/etlhelper/db_helpers/sqlite.py
+++ b/etlhelper/db_helpers/sqlite.py
@@ -17,7 +17,7 @@ class SQLiteDbHelper(DbHelper):
     table_info_query = dedent("""
         SELECT
             name,
-            type,
+            lower(type),
             "notnull" as not_null,
             (case when dflt_value is not null then 1 else 0 end) as has_default
         FROM pragma_table_info(:table_name)


### PR DESCRIPTION
This merge request updates the table info returned by SQLite to ensure that the `type` is in lower case.  A recent change to `sqlite3` changed the response, causing our test suite to fail.