### PR TITLE
Read LOBs as string/bytes instead of streaming

### DIFF
--- a/etlhelper/db_helpers/oracle.py
+++ b/etlhelper/db_helpers/oracle.py
@@ -39,6 +39,13 @@ class OracleDbHelper(DbHelper):
                                        oracledb.InterfaceError)
             self.paramstyle = oracledb.paramstyle
             self._connect_func = oracledb.connect
+
+            # Fetch large objects as Python strings/bytes instead of LOBs
+            # The oracledb default is LOB, but native types are faster to
+            # transfer and are in line with return types of other databases
+            # e.g. SQLite or PostgreSQL.
+            # https://python-oracledb.readthedocs.io/en/latest/user_guide/lob_data.html#fetching-lobs-as-strings-and-bytes
+            oracledb.defaults.fetch_lobs = False
         except ImportError:
             warnings.warn(self.missing_driver_msg)
 


### PR DESCRIPTION
### Summary

This merge request updates the default behaviour of the `oracledb` driver so that LOB data are returned as native Python strings/bytes.

It includes updated documentation and a test to confirm the mechanism for switching between string/bytes and LOB return types.  It also confirms that LOBs longer than 4000 characters are returned intact.

Closes #110

### To test

+ [x] Confirm that test suite passes

Ideally, we would also run code from this branch against internal BGS spatial data scripts to confirm that they still work.