### PR TITLE
Deprecate get rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ database with Python.
 
 + `setup_oracle_client` script installs Oracle Instant Client on Linux systems
 + `DbParams` objects provide consistent way to connect to different database types (currently Oracle, PostgreSQL, SQLite and MS SQL Server)
-+ `get_rows`, `iter_rows`, `fetchone` and other functions for querying database
++ `fetchall`, `iter_rows`, `fetchone` and other functions for querying database
 + `execute`, `executemany`, and `load` functions to insert data
 + `copy_rows` and `copy_table_rows` to transfer data from one database to another
 + `on_error` function to process rows that fail to insert
@@ -202,19 +202,19 @@ No password is required for SQLite databases.
 
 ## Transfer data
 
-### Get rows
+### Fetch all
 
-The `get_rows` function returns a list of named tuples containing data as
+The `fetchall` function returns a list of named tuples containing data as
 native Python objects.
 
 ```python
 from my_databases import ORACLEDB
-from etlhelper import get_rows
+from etlhelper import fetchall
 
 sql = "SELECT * FROM src"
 
 with ORACLEDB.connect("ORA_PASSWORD") as conn:
-    get_rows(sql, conn)
+    fetchall(sql, conn)
 ```
 
 returns
@@ -266,7 +266,7 @@ placeholders.
 select_sql = "SELECT * FROM src WHERE id = :id"
 
 with ORACLEDB.connect("ORA_PASSWORD") as conn:
-    get_rows(sql, conn, parameters={'id': 1})
+    fetchall(sql, conn, parameters={'id': 1})
 ```
 
 #### Row factories
@@ -276,13 +276,13 @@ Row factories control the output format of returned rows.
 For example return each row as a dictionary, use the following:
 
 ```python
-from etlhelper import get_rows
+from etlhelper import fetchall
 from etlhelper.row_factories import dict_row_factory
 
 sql = "SELECT * FROM my_table"
 
 with ORACLEDB.connect('ORACLE_PASSWORD') as conn:
-    for row in get_rows(sql, conn, row_factory=dict_row_factory):
+    for row in fetchall(sql, conn, row_factory=dict_row_factory):
         print(row['id'])
 ```
 
@@ -558,7 +558,7 @@ def my_transform(chunk: Iterator[dict]) -> Iterator[dict]:
         yield row
 
 
-get_rows(select_sql, src_conn, row_factory=dict_row_factory,
+fetchall(select_sql, src_conn, row_factory=dict_row_factory,
          transform=my_transform)
 ```
 
@@ -586,7 +586,7 @@ def my_transform(chunk: Iterator[tuple]) -> list[tuple]:
 
     return new_chunk
 
-get_rows(select_sql, src_conn, row_factory=namedtuple_row_factory,
+fetchall(select_sql, src_conn, row_factory=namedtuple_row_factory,
          transform=my_transform)
 ```
 

--- a/etlhelper/__init__.py
+++ b/etlhelper/__init__.py
@@ -21,7 +21,6 @@ from etlhelper.etl import (
     fetchone,
     fetchall,
     generate_insert_sql,
-    get_rows,
     iter_chunks,
     iter_rows,
     load,

--- a/etlhelper/etl.py
+++ b/etlhelper/etl.py
@@ -134,24 +134,6 @@ def iter_rows(select_query, conn, parameters=(),
             yield row
 
 
-def get_rows(select_query, conn, parameters=(),
-             row_factory=namedtuple_row_factory, transform=None,
-             chunk_size=CHUNKSIZE):
-    """
-    Get results of query as a list.  See iter_rows for details.
-    :param select_query: str, SQL query to execute
-    :param conn: dbapi connection
-    :param parameters: sequence or dict of bind variables to insert in the query
-    :param row_factory: function that accepts a cursor and returns a function for parsing each row
-    :param transform: function that accepts an iterable (e.g. list) of rows and returns an iterable
-                      of rows (possibly of different shape)
-    :param chunk_size: int, size of chunks to group data by
-    """
-    return list(iter_rows(select_query, conn, row_factory=row_factory,
-                          parameters=parameters, transform=transform,
-                          chunk_size=chunk_size))
-
-
 def fetchone(select_query, conn, parameters=(),
              row_factory=namedtuple_row_factory, transform=None,
              chunk_size=1):

--- a/test/integration/db/test_mssql.py
+++ b/test/integration/db/test_mssql.py
@@ -15,7 +15,7 @@ from etlhelper import (
     copy_rows,
     copy_table_rows,
     execute,
-    get_rows,
+    fetchall,
     generate_insert_sql,
     load,
 )
@@ -75,7 +75,7 @@ def test_copy_rows_happy_path_fast_true(
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
     assert result == test_table_data
 
 
@@ -95,7 +95,7 @@ def test_copy_rows_happy_path_deprecated_tables_fast_true(
         "fast_executemany execution failed")
 
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
     assert result == test_table_data
 
 
@@ -110,7 +110,7 @@ def test_copy_rows_happy_path_fast_false(
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_fast_false_conn)
+    result = fetchall(sql, testdb_fast_false_conn)
     assert result == test_table_data
 
 
@@ -125,7 +125,7 @@ def test_copy_rows_happy_path_deprecated_tables_fast_false(
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_fast_false_conn)
+    result = fetchall(sql, testdb_fast_false_conn)
     assert result == test_table_data
 
 
@@ -138,7 +138,7 @@ def test_copy_table_rows_happy_path_fast_true(
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
     assert result == test_table_data
 
 
@@ -159,7 +159,7 @@ def test_copy_table_rows_on_error(test_tables, testdb_conn, test_table_data):
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
 
     # Check that first row was caught as error
     row, exception = errors[0]
@@ -170,13 +170,13 @@ def test_copy_table_rows_on_error(test_tables, testdb_conn, test_table_data):
     assert result[1:] == test_table_data[1:]
 
 
-def test_get_rows_with_parameters(test_tables, testdb_conn,
+def test_fetchall_with_parameters(test_tables, testdb_conn,
                                   test_table_data):
     # parameters=None is tested by default in other tests
 
     # Bind by index
     sql = "SELECT * FROM src where ID = ?"
-    result = get_rows(sql, testdb_conn, parameters=(1,))
+    result = fetchall(sql, testdb_conn, parameters=(1,))
     assert len(result) == 1
     assert result[0].id == 1
 
@@ -195,7 +195,7 @@ def test_load_named_tuples(testdb_conn, test_tables, test_table_data):
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
     assert result == test_table_data
 
 

--- a/test/integration/db/test_oracle.py
+++ b/test/integration/db/test_oracle.py
@@ -15,7 +15,7 @@ from etlhelper import (
     copy_rows,
     copy_table_rows,
     execute,
-    get_rows,
+    fetchall,
     generate_insert_sql,
     load,
 )
@@ -72,7 +72,7 @@ def test_copy_rows_happy_path(test_tables, testdb_conn, test_table_data):
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
 
     # Fix result date and datetime strings to native classes
     fixed_dates = []
@@ -92,7 +92,7 @@ def test_copy_table_rows_happy_path(test_tables, testdb_conn, test_table_data):
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
 
     # Fix result date and datetime strings to native classes
     fixed_dates = []
@@ -123,7 +123,7 @@ def test_copy_table_rows_on_error(test_tables, testdb_conn, test_table_data):
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
 
     # Check that first row was caught as error, noting that Oracle
     # changes the case of column names
@@ -144,13 +144,13 @@ def test_copy_table_rows_on_error(test_tables, testdb_conn, test_table_data):
     assert fixed_dates == test_table_data[1:]
 
 
-def test_get_rows_with_parameters(test_tables, testdb_conn,
+def test_fetchall_with_parameters(test_tables, testdb_conn,
                                   test_table_data):
     # parameters=None is tested by default in other tests
 
     # Bind by index
     sql = "SELECT * FROM src where ID = :1"
-    result = get_rows(sql, testdb_conn, parameters=(1,))
+    result = fetchall(sql, testdb_conn, parameters=(1,))
     assert len(result) == 1
     assert result[0].ID == 1
 
@@ -173,7 +173,7 @@ def test_load_named_tuples(testdb_conn, test_tables, test_table_data):
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
 
     # Fix result date and datetime strings to native classes
     fixed_dates = []
@@ -200,7 +200,7 @@ def test_load_dicts(testdb_conn, test_tables, test_table_data):
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
 
     # Fix result date and datetime strings to native classes
     fixed_dates = []

--- a/test/integration/db/test_sqlite.py
+++ b/test/integration/db/test_sqlite.py
@@ -16,7 +16,7 @@ from etlhelper import (
     copy_rows,
     copy_table_rows,
     execute,
-    get_rows,
+    fetchall,
     generate_insert_sql,
     load,
 )
@@ -75,7 +75,7 @@ def test_copy_rows_happy_path(test_tables, testdb_conn, test_table_data):
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
 
     assert result == test_table_data
 
@@ -86,7 +86,7 @@ def test_copy_table_rows_happy_path(test_tables, testdb_conn, test_table_data):
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
 
     assert result == test_table_data
 
@@ -108,7 +108,7 @@ def test_copy_table_rows_on_error(test_tables, testdb_conn, test_table_data):
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
 
     # Check that first row was caught as error
     row, exception = errors[0]
@@ -119,13 +119,13 @@ def test_copy_table_rows_on_error(test_tables, testdb_conn, test_table_data):
     assert result[1:] == test_table_data[1:]
 
 
-def test_get_rows_with_parameters(test_tables, testdb_conn,
+def test_fetchall_with_parameters(test_tables, testdb_conn,
                                   test_table_data):
     # parameters=None is tested by default in other tests
 
     # Bind by index
     sql = "SELECT * FROM src where ID = ?"
-    result = get_rows(sql, testdb_conn, parameters=(1,))
+    result = fetchall(sql, testdb_conn, parameters=(1,))
     assert len(result) == 1
     assert result[0].id == 1
 
@@ -144,7 +144,7 @@ def test_load_named_tuples(testdb_conn, test_tables, test_table_data):
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
 
     assert result == test_table_data
 
@@ -158,7 +158,7 @@ def test_load_dicts(testdb_conn, test_tables, test_table_data):
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, testdb_conn)
+    result = fetchall(sql, testdb_conn)
 
     assert result == test_table_data
 

--- a/test/integration/etl/test_etl_extract.py
+++ b/test/integration/etl/test_etl_extract.py
@@ -16,7 +16,6 @@ import etlhelper.etl as etlhelper_etl
 from etlhelper import (
     iter_chunks,
     iter_rows,
-    get_rows,
     execute,
     fetchone,
     fetchall,
@@ -166,13 +165,13 @@ def test_iter_rows_bad_query(pgtestdb_test_tables, pgtestdb_conn):
         list(result)  # Call list to activate returned generator
 
 
-def test_get_rows_happy_path(
+def test_fetchall_happy_path(
     pgtestdb_test_tables,
     pgtestdb_conn,
     test_table_data,
 ):
     sql = "SELECT * FROM src"
-    result = get_rows(sql, pgtestdb_conn)
+    result = fetchall(sql, pgtestdb_conn)
     assert result == test_table_data
 
 
@@ -213,7 +212,7 @@ def test_fetchone_closes_transaction(pgtestdb_conn):
 
 @pytest.mark.parametrize(
     "fetch_func",
-    [fetchall, get_rows],
+    [fetchall],
 )
 def test_fetch_funcs_close_transaction(pgtestdb_conn, fetch_func):
     sql = "SELECT now() AS time"
@@ -242,7 +241,7 @@ def test_fetchall_happy_path(
 
 @pytest.mark.parametrize(
     "fetchmethod",
-    ["get_rows", "fetchone", "fetchall"],
+    ["fetchone", "fetchall"],
 )
 def test_arguments_passed_to_iter_rows(
     monkeypatch,
@@ -302,7 +301,7 @@ def test_execute_happy_path(pgtestdb_test_tables, pgtestdb_conn):
     execute(sql, pgtestdb_conn)
 
     # Assert
-    result = get_rows("SELECT * FROM src;", pgtestdb_conn)
+    result = fetchall("SELECT * FROM src;", pgtestdb_conn)
     assert result == []
 
 
@@ -320,7 +319,7 @@ def test_execute_with_params(
     execute(sql, pgtestdb_conn, parameters=params)
 
     # Assert
-    result = get_rows("SELECT * FROM src;", pgtestdb_conn)
+    result = fetchall("SELECT * FROM src;", pgtestdb_conn)
     assert result == expected
 
 

--- a/test/integration/etl/test_etl_extract.py
+++ b/test/integration/etl/test_etl_extract.py
@@ -165,16 +165,6 @@ def test_iter_rows_bad_query(pgtestdb_test_tables, pgtestdb_conn):
         list(result)  # Call list to activate returned generator
 
 
-def test_fetchall_happy_path(
-    pgtestdb_test_tables,
-    pgtestdb_conn,
-    test_table_data,
-):
-    sql = "SELECT * FROM src"
-    result = fetchall(sql, pgtestdb_conn)
-    assert result == test_table_data
-
-
 def test_fetchone_happy_path(
     pgtestdb_test_tables,
     pgtestdb_conn,

--- a/test/integration/etl/test_etl_load.py
+++ b/test/integration/etl/test_etl_load.py
@@ -10,7 +10,7 @@ import pytest
 from etlhelper import (
     executemany,
     generate_insert_sql,
-    get_rows,
+    fetchall,
     iter_rows,
     load)
 from etlhelper.etl import ETLHelperInsertError
@@ -35,7 +35,7 @@ def test_insert_rows_happy_path(pgtestdb_conn, pgtestdb_test_tables,
     assert failed == 0
 
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
+    result = fetchall(sql, pgtestdb_conn)
     assert result == test_table_data
 
 
@@ -59,7 +59,7 @@ def test_insert_rows_on_error(pgtestdb_conn, pgtestdb_test_tables,
     assert failed == len(errors)
 
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
+    result = fetchall(sql, pgtestdb_conn)
     assert result == test_table_data
 
     # Assert full set of failed rows failing unique constraint
@@ -81,7 +81,7 @@ def test_insert_rows_chunked(pgtestdb_conn, pgtestdb_test_tables,
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
+    result = fetchall(sql, pgtestdb_conn)
     assert result == test_table_data
 
 
@@ -120,7 +120,7 @@ def test_load_named_tuples(pgtestdb_conn, pgtestdb_test_tables, test_table_data)
     assert failed == 0
 
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
+    result = fetchall(sql, pgtestdb_conn)
     assert result == test_table_data
 
 
@@ -136,7 +136,7 @@ def test_load_dicts(pgtestdb_conn, pgtestdb_test_tables, test_table_data):
     assert failed == 0
 
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
+    result = fetchall(sql, pgtestdb_conn)
     assert result == test_table_data
 
 
@@ -153,7 +153,7 @@ def test_load_named_tuples_with_transform_generator(pgtestdb_conn, pgtestdb_test
     assert failed == 0
 
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
+    result = fetchall(sql, pgtestdb_conn)
     assert result == test_table_data
 
 
@@ -180,7 +180,7 @@ def test_load_named_tuples_chunk_size(pgtestdb_conn, pgtestdb_test_tables,
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
+    result = fetchall(sql, pgtestdb_conn)
     assert result == test_table_data
 
 

--- a/test/integration/etl/test_etl_transform.py
+++ b/test/integration/etl/test_etl_transform.py
@@ -10,7 +10,7 @@ from etlhelper import (
     copy_rows,
     copy_table_rows,
     execute,
-    get_rows,
+    fetchall,
     iter_rows,
     load,
 )
@@ -44,7 +44,7 @@ def test_copy_table_rows_happy_path(pgtestdb_conn, pgtestdb_test_tables,
     assert failed == 0
 
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
+    result = fetchall(sql, pgtestdb_conn)
     assert result == test_table_data
 
 
@@ -66,7 +66,7 @@ def test_copy_table_rows_on_error(pgtestdb_test_tables, pgtestdb_conn,
     assert failed == len(errors)
 
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
+    result = fetchall(sql, pgtestdb_conn)
 
     # Check that first row was caught as error
     row, exception = errors[0]
@@ -153,7 +153,7 @@ def transform_yield_modified_dict(chunk):
         yield row
 
 
-def test_get_rows_with_modify_dict(pgtestdb_conn, pgtestdb_test_tables):
+def test_fetchall_with_modify_dict(pgtestdb_conn, pgtestdb_test_tables):
     # Arrange
     select_sql = "SELECT * FROM src LIMIT 1"
     expected = [{
@@ -166,7 +166,7 @@ def test_get_rows_with_modify_dict(pgtestdb_conn, pgtestdb_test_tables):
     }]
 
     # Act
-    result = get_rows(select_sql, pgtestdb_conn, row_factory=dict_row_factory,
+    result = fetchall(select_sql, pgtestdb_conn, row_factory=dict_row_factory,
                       transform=transform_yield_modified_dict)
 
     # Assert
@@ -194,7 +194,7 @@ def test_copy_rows_with_dict_row_factory(pgtestdb_conn, pgtestdb_test_tables, pg
 
     # Assert
     sql = "SELECT * FROM dest"
-    result = get_rows(sql, pgtestdb_conn)
+    result = fetchall(sql, pgtestdb_conn)
     assert result == expected
 
 
@@ -285,7 +285,7 @@ def test_load_transform(
     )
 
     sql = "SELECT * FROM src"
-    result = get_rows(sql, pgtestdb_conn)
+    result = fetchall(sql, pgtestdb_conn)
 
     # Assert
     for i, row in enumerate(result):


### PR DESCRIPTION
### Summary

The function `get_rows` has been deprecated in favour of `fetchall`. This change has been made across the code, tests and documentation.

Closes #176