### PR TITLE
Bump ubuntu version and use python 3.10

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pages:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -24,3 +24,5 @@ jobs:
           pip install sphinx sphinx_rtd_theme
     - id: deployment
       uses: sphinx-notes/pages@v3
+      with:
+        python-version: '3.10'


### PR DESCRIPTION
### Summary

The current `sphinx` build uses Python `3.8`, which is older than the minimum version for `etlhelper` (`3.9`). This meant that the docs could not understand our typehints, which then caused the docs to fail to build some pages.