### PR TITLE
added type hint to connection types in db_helper_factory

### DIFF
--- a/etlhelper/db_helper_factory.py
+++ b/etlhelper/db_helper_factory.py
@@ -18,7 +18,7 @@ class DbHelperFactory():
     """
     def __init__(self):
         self.helpers = {}
-        self._conn_types = {}
+        self._conn_types: dict[str, str] = {}
 
     def register_helper(self, dbtype, conn_type, db_helper):
         """


### PR DESCRIPTION
This pull request adds a missing typehint to the `db_helper_factory.py` script.