### PR TITLE
Run tests on newer Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
   push:
     paths:
       - '**.py'
+      - '.github/workflows/test.yml'
 
 jobs:
   flake8_py3:
@@ -51,7 +52,7 @@ jobs:
           --health-retries 5
     strategy:
       matrix:
-        python-version: [3.9, '3.10', 3.11]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
### Summary

This merge request applies a small change to run the pipeline tests against these newer Python versions:
-  `3.12`
- `3.13`

This means our tests are now run against Python version `3.9` through to `3.13` successfully.