### PR TITLE
Explicitly list packages/sub-directories within package directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,4 +58,4 @@ pkg = [
 # pull new tag, then run build
 
 [tool.setuptools]
-packages = ["etlhelper"]
+packages = ["etlhelper", "etlhelper.db_helpers"]


### PR DESCRIPTION
### Summary

This pull request addresses #212 by explicitly including `etlhelper.db_helpers` in the list of packages in the `pyproject.toml`.

Closes #212