### PR TITLE
Fix typo in Python code example for fetchall

### DIFF
--- a/docs/etl_functions/extract.rst
+++ b/docs/etl_functions/extract.rst
@@ -79,7 +79,7 @@ A dictionary is used for named placeholders,
    select_sql = "SELECT * FROM src WHERE id = :id"  # SQLite style
 
    with sqlite3.connect("rocks.db") as conn:
-       etl.fetchall(sql, conn, parameters={'id': 1})
+       etl.fetchall(select_sql, conn, parameters={'id': 1})
 
 or a tuple for positional placeholders.
 
@@ -88,7 +88,7 @@ or a tuple for positional placeholders.
    select_sql = "SELECT * FROM src WHERE id = ?"  # SQLite style
 
    with sqlite3.connect("rocks.db") as conn:
-       etl.fetchall(sql, conn, parameters=(1,))
+       etl.fetchall(select_sql, conn, parameters=(1,))
 
 
 Named parameters result in more readable code.


### PR DESCRIPTION
### Summary

This pull request fixes a small typo in the documentation, specifically one of the Python code examples for `etl.fetchall`. A variable is defined called `sql_select`, but then later it is referenced as `sql`. This would cause a error as `sql` is not defined.