### PR TITLE
Bump sphinx action version

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,6 +23,6 @@ jobs:
       run: |
           pip install sphinx sphinx_rtd_theme
     - id: deployment
-      uses: sphinx-notes/pages@f7cabbad7f99057f9617e73ea57b40c5fedb53bc  # v3
+      uses: sphinx-notes/pages@e9c8f79f285fb41a150ba6e08a3c2a29635e7ee1  # v3.5
       with:
         python-version: '3.10'


### PR DESCRIPTION
### Summary

#230 was merged but has caused the documentation build to fail with sphinx. The error message can be seen using the job link below, but it looks like it was to do with pinning an old version of the sphinx action which uses deprecated actions. Therefore, this merge request bumps the sphinx action to version `3.5`. I did not choose `3.6` as it was only released 2 weeks ago.

https://github.com/BritishGeologicalSurvey/etlhelper/actions/runs/25216442859/job/73937840246